### PR TITLE
Introduces Popconfirm component

### DIFF
--- a/src/lib/components/Form/CommentsPanel.svelte
+++ b/src/lib/components/Form/CommentsPanel.svelte
@@ -9,6 +9,7 @@
   import { getContext } from "svelte";
   import type { Token } from "$lib/models/keycloak";
   import { fly } from "svelte/transition";
+  import { popconfirm } from "$lib/context/PopConfirmContex.svelte";
 
   type CommentsPanelProps = {
     metadata?: MetadataJson;
@@ -42,20 +43,26 @@
     }
   }
 
-  async function deleteIcon(id: string) {
-    const response = await fetch(page.url.pathname + '/comment', {
-      method: 'DELETE',
-      headers: {
-        'content-type': 'application/json'
-      },
-      body: JSON.stringify({
-        id
-      })
-    });
+  async function onDelete(id: string, evt: MouseEvent) {
+    const targetEl = evt.currentTarget as HTMLElement;
+    popconfirm(targetEl, async () => {
+      const response = await fetch(page.url.pathname + '/comment', {
+        method: 'DELETE',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          id
+        })
+      });
 
-    if (response.ok) {
-      invalidateAll();
-    }
+      if (response.ok) {
+        invalidateAll();
+      }
+    }, {
+      text: 'Möchten Sie diesen Kommentar wirklich löschen?',
+      confirmButtonText: 'Löschen'
+    });
   }
 
   function isDeletable(comment: Comment, index: number) {
@@ -86,7 +93,7 @@
             {#if isDeletable(comment, index)}
               <Icon
                 class="material-icons delete-icon"
-                onclick={() => deleteIcon(comment.id)}
+                onclick={(evt) => onDelete(comment.id, evt)}
               >
                 delete
               </Icon>

--- a/src/lib/components/Form/CopyButton.svelte
+++ b/src/lib/components/Form/CopyButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import IconButton from "@smui/icon-button";
   import { Icon } from "@smui/button";
-  import { getValue } from "./FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
 
   let {
     key,

--- a/src/lib/components/Form/Field/AdditionalInformation_39.svelte
+++ b/src/lib/components/Form/Field/AdditionalInformation_39.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import IconButton from "@smui/icon-button";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import TextInput from "../Inputs/TextInput.svelte";
   import FieldTools from "../FieldTools.svelte";
   import { fly, scale } from "svelte/transition";

--- a/src/lib/components/Form/Field/AnnexThemeField_07.svelte
+++ b/src/lib/components/Form/Field/AnnexThemeField_07.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import SelectInput from "../Inputs/SelectInput.svelte";
   import { invalidateAll } from "$app/navigation";

--- a/src/lib/components/Form/Field/ContactsField_19.svelte
+++ b/src/lib/components/Form/Field/ContactsField_19.svelte
@@ -2,13 +2,14 @@
   import { page } from "$app/state";
   import type { Contacts } from "$lib/models/metadata";
   import IconButton from "@smui/icon-button";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import TextInput from "../Inputs/TextInput.svelte";
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import { fly, scale } from "svelte/transition";
   import ValidationFeedbackText from "../ValidationFeedbackText.svelte";
   import type { ValidationResult, ValidationResultList } from "../FieldsConfig";
+  import { popconfirm } from "$lib/context/PopConfirmContex.svelte";
 
   const KEY = 'isoMetadata.pointsOfContact';
   const LABEL = 'Kontakt';
@@ -68,10 +69,15 @@
     ];
   };
 
-  const removeItem = (listId: string) => {
-    // TODO: add popconfirm
-    contacts = contacts.filter(contact => contact.listId !== listId);
-    persistContacts();
+  const removeItem = (listId: string, evt: MouseEvent) => {
+    const targetEl = evt.currentTarget as HTMLElement;
+    popconfirm(targetEl, async () => {
+      contacts = contacts.filter(contact => contact.listId !== listId);
+      persistContacts();
+    }, {
+      text: 'Möchten Sie diesen Kontakt wirklich löschen?',
+      confirmButtonText: 'Löschen'
+    })
   };
 
   const getFieldValidation = (i: number, k: string): ValidationResult | undefined => {
@@ -98,7 +104,7 @@
         <legend>
           <IconButton
           class="material-icons"
-          onclick={() => removeItem(contact.listId)}
+          onclick={(evt) => removeItem(contact.listId, evt)}
           size="button"
           title="Kontakt entfernen"
         >

--- a/src/lib/components/Form/Field/ContentDescriptionTextarea_31.svelte
+++ b/src/lib/components/Form/Field/ContentDescriptionTextarea_31.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import FieldTools from "../FieldTools.svelte";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import TextAreaInput from "../Inputs/TextAreaInput.svelte";
 
   const KEY = 'isoMetadata.UNKNOWN';

--- a/src/lib/components/Form/Field/ContentDescription_30.svelte
+++ b/src/lib/components/Form/Field/ContentDescription_30.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import IconButton from "@smui/icon-button";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import TextInput from "../Inputs/TextInput.svelte";
   import FieldTools from "../FieldTools.svelte";
   import { fly, scale } from "svelte/transition";

--- a/src/lib/components/Form/Field/CoordinateSystemField_17.svelte
+++ b/src/lib/components/Form/Field/CoordinateSystemField_17.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import SelectInput from "../Inputs/SelectInput.svelte";

--- a/src/lib/components/Form/Field/CreatedField_09.svelte
+++ b/src/lib/components/Form/Field/CreatedField_09.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import DateInput from "../Inputs/DateInput.svelte";

--- a/src/lib/components/Form/Field/DataProtectionField_04.svelte
+++ b/src/lib/components/Form/Field/DataProtectionField_04.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Paper from "@smui/paper";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import CheckboxInput from "../Inputs/CheckboxInput.svelte";
 

--- a/src/lib/components/Form/Field/DeliveredCoordinateSystemField_16.svelte
+++ b/src/lib/components/Form/Field/DeliveredCoordinateSystemField_16.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/state";
   import TextInput from "$lib/components/Form/Inputs/TextInput.svelte";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import type { ValidationResult } from "../FieldsConfig";

--- a/src/lib/components/Form/Field/DescriptionField_02.svelte
+++ b/src/lib/components/Form/Field/DescriptionField_02.svelte
@@ -3,7 +3,7 @@
   import { page } from "$app/state";
   import type { ValidationResult } from "../FieldsConfig";
   import FieldTools from "../FieldTools.svelte";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import TextAreaInput from "../Inputs/TextAreaInput.svelte";
 
   const KEY = 'isoMetadata.description';

--- a/src/lib/components/Form/Field/ExtentField_18.svelte
+++ b/src/lib/components/Form/Field/ExtentField_18.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import NumberInput from "../Inputs/NumberInput.svelte";
   import type { CRS, Extent } from "$lib/models/metadata";

--- a/src/lib/components/Form/Field/HighValueDatasetField_06.svelte
+++ b/src/lib/components/Form/Field/HighValueDatasetField_06.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import Switch from "@smui/switch";
   import FormField from "@smui/form-field";

--- a/src/lib/components/Form/Field/KeywordsField_15.svelte
+++ b/src/lib/components/Form/Field/KeywordsField_15.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import type { KeyWords } from "$lib/models/metadata";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import { onMount } from "svelte";

--- a/src/lib/components/Form/Field/LastUpdatedField_11.svelte
+++ b/src/lib/components/Form/Field/LastUpdatedField_11.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import DateInput from "../Inputs/DateInput.svelte";

--- a/src/lib/components/Form/Field/Lineage_32.svelte
+++ b/src/lib/components/Form/Field/Lineage_32.svelte
@@ -2,7 +2,7 @@
   // import { page } from "$app/state";
   import type { Lineage } from "$lib/models/metadata";
   import IconButton from "@smui/icon-button";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import TextInput from "../Inputs/TextInput.svelte";
   import FieldTools from "../FieldTools.svelte";
   // import { invalidateAll } from "$app/navigation";

--- a/src/lib/components/Form/Field/MaintenanceFrequencyField_14.svelte
+++ b/src/lib/components/Form/Field/MaintenanceFrequencyField_14.svelte
@@ -1,7 +1,7 @@
 <script lang='ts'>
   import { page } from '$app/state';
   import Paper from '@smui/paper';
-  import { getFieldConfig, getValue } from '../FormContext.svelte';
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from '../FieldTools.svelte';
   import { invalidateAll } from '$app/navigation';
   import SelectInput from '../Inputs/SelectInput.svelte';

--- a/src/lib/components/Form/Field/MetadataProfile_05.svelte
+++ b/src/lib/components/Form/Field/MetadataProfile_05.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import SelectInput from "../Inputs/SelectInput.svelte";

--- a/src/lib/components/Form/Field/PreviewField_29.svelte
+++ b/src/lib/components/Form/Field/PreviewField_29.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/state";
   import TextInput from "$lib/components/Form/Inputs/TextInput.svelte";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import type { ValidationResult } from "../FieldsConfig";

--- a/src/lib/components/Form/Field/PublishedField_10.svelte
+++ b/src/lib/components/Form/Field/PublishedField_10.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import DateInput from "../Inputs/DateInput.svelte";

--- a/src/lib/components/Form/Field/QualityReportCheckField_37.svelte
+++ b/src/lib/components/Form/Field/QualityReportCheckField_37.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import FormField from "@smui/form-field";

--- a/src/lib/components/Form/Field/ResolutionField_28.svelte
+++ b/src/lib/components/Form/Field/ResolutionField_28.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import NumberInput from "../Inputs/NumberInput.svelte";
   import { invalidateAll } from "$app/navigation";

--- a/src/lib/components/Form/Field/TechnicalDescription_60.svelte
+++ b/src/lib/components/Form/Field/TechnicalDescription_60.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/state";
   import TextInput from "$lib/components/Form/Inputs/TextInput.svelte";
   import Paper from "@smui/paper";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
 

--- a/src/lib/components/Form/Field/TermsOfUseField_24.svelte
+++ b/src/lib/components/Form/Field/TermsOfUseField_24.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import SelectInput from "../Inputs/SelectInput.svelte";
   import type { TermsOfUse } from "$lib/models/metadata";

--- a/src/lib/components/Form/Field/TitleField_01.svelte
+++ b/src/lib/components/Form/Field/TitleField_01.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/state";
   import TextInput from "$lib/components/Form/Inputs/TextInput.svelte";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import { invalidateAll } from "$app/navigation";
   import type { ValidationResult } from "../FieldsConfig";

--- a/src/lib/components/Form/Field/TopicCategory_13.svelte
+++ b/src/lib/components/Form/Field/TopicCategory_13.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Paper from "@smui/paper";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import SelectInput from "../Inputs/SelectInput.svelte";
   import { invalidateAll } from "$app/navigation";

--- a/src/lib/components/Form/Field/ValidityRangeField_12.svelte
+++ b/src/lib/components/Form/Field/ValidityRangeField_12.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { getFieldConfig, getValue } from "../FormContext.svelte";
+  import { getFieldConfig, getValue } from "$lib/context/FormContext.svelte";;
   import FieldTools from "../FieldTools.svelte";
   import DateInput from "../Inputs/DateInput.svelte";
   import { invalidateAll } from "$app/navigation";

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { FieldKey } from "$lib/models/form";
 import type { Contacts, Extent } from "$lib/models/metadata";
-import type { Section } from "./FormContext.svelte";
+import type { Section } from "$lib/context/FormContext.svelte";;
 
 export type ValidationResult = {
   valid: boolean;

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -9,7 +9,7 @@
     getProgress,
     type Section,
     clearActiveHelp
-  } from "./FormContext.svelte";
+  } from "$lib/context/FormContext.svelte";;
   import TitleField_01 from "./Field/TitleField_01.svelte";
   import DescriptionField_02 from "./Field/DescriptionField_02.svelte";
   import KeywordsField_15 from "./Field/KeywordsField_15.svelte";

--- a/src/lib/components/Form/FormFooter.svelte
+++ b/src/lib/components/Form/FormFooter.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { allFieldsValid } from "./FormContext.svelte";
+  import { allFieldsValid } from "$lib/context/FormContext.svelte";;
   import CommentsPanel from "./CommentsPanel.svelte";
   import Button, { Icon, Label } from "@smui/button";
   import type { MetadataJson } from "$lib/models/metadata";

--- a/src/lib/components/Form/HelpButton.svelte
+++ b/src/lib/components/Form/HelpButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import IconButton from "@smui/icon-button";
   import { Icon } from "@smui/button";
-  import { getFormContext, toggleActiveHelp } from "./FormContext.svelte";
+  import { getFormContext, toggleActiveHelp } from "$lib/context/FormContext.svelte";;
 
   let {
     key

--- a/src/lib/components/Form/HelpPanel.svelte
+++ b/src/lib/components/Form/HelpPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   /* eslint-disable svelte/no-at-html-tags */
-  import { getFormContext } from "./FormContext.svelte";
+  import { getFormContext } from "$lib/context/FormContext.svelte";;
   const activeHelpKey = $derived(getFormContext().activeHelpKey);
 
   const getHelpMarkdown = async (key: string) => {

--- a/src/lib/components/Form/service/ServicesSection.svelte
+++ b/src/lib/components/Form/service/ServicesSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import IconButton from "@smui/icon-button";
-  import { getValue } from "../FormContext.svelte";
+  import { getValue } from "$lib/context/FormContext.svelte";;
   import type { Service } from "$lib/models/metadata";
   import ServiceForm from "./ServiceForm.svelte";
   import { invalidateAll } from "$app/navigation";

--- a/src/lib/components/Popconfirm.svelte
+++ b/src/lib/components/Popconfirm.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { closePopconfirm, getPopconfirmState } from '$lib/context/PopConfirmContex.svelte';
+  import Button from '@smui/button';
+
+  const {
+    anchorElement,
+    confirmButtonText,
+    open,
+    onConfirm,
+    onCancel,
+    text,
+  } = $derived(getPopconfirmState());
+
+  let dialog = $state<HTMLDialogElement>();
+
+  const anchorRect = $derived(anchorElement?.getBoundingClientRect());
+
+  const confirmButtonHandler = () => {
+    onConfirm();
+    closePopconfirm();
+  };
+
+</script>
+
+<dialog
+  class="popconfirm"
+  bind:this={dialog}
+  {open}
+  style={`
+    top: ${anchorRect?.top}px;
+    left: ${anchorRect?.right}px;
+  `}
+>
+  <span class="confirmation-text">
+    {text}
+  </span>
+  <div class="actions">
+    <Button
+      variant="unelevated"
+      onclick={confirmButtonHandler}
+    >
+      {confirmButtonText}
+    </Button>
+  </div>
+</dialog>
+
+{#if open}
+  <div
+    class="mask"
+    onclick={onCancel}
+    onkeydown={onCancel}
+    role="button"
+    tabindex="0"
+  >
+  </div>
+{/if}
+
+<style lang="scss">
+  .popconfirm {
+    position: fixed;
+    margin: 0;
+    z-index: 1000;
+    background-color: var(--mdc-theme-surface);
+    border: 1px solid var(--mdc-theme-primary);
+    transform: translate(5%, -80%);
+    border-radius: 8px;
+    padding: 0.25em;
+
+    .confirmation-text {
+      max-width: 200px;
+      text-align: center;
+      padding: 0.5em;
+      display: block;
+    }
+
+    .actions {
+      display: flex;
+      justify-content: center;
+    }
+  }
+
+  .mask {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.1);
+      z-index: 1;
+    }
+</style>

--- a/src/lib/context/FormContext.svelte.ts
+++ b/src/lib/context/FormContext.svelte.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getContext, setContext } from "svelte";
 import type { FieldKey } from "$lib/models/form";
-import { FieldConfigs, type FieldConfig } from "./FieldsConfig";
+import { FieldConfigs, type FieldConfig } from "$lib/components/Form/FieldsConfig";
 
 export type FormState = {
   data: Record<string, unknown>;

--- a/src/lib/context/PopConfirmContex.svelte.ts
+++ b/src/lib/context/PopConfirmContex.svelte.ts
@@ -1,0 +1,46 @@
+import { getContext, setContext } from "svelte";
+
+export const POPCONFIRM_CONTEXT = Symbol('popconfirm');
+
+export type PopconfirmState = {
+  open: boolean;
+  text?: string;
+  anchorElement?: HTMLElement;
+  confirmButtonText?: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+};
+
+type ConfirmOptions = Omit<PopconfirmState, 'open' | 'onConfirm' | 'targetEl'>;
+
+const defaultState = {
+  open: false,
+  text: 'Sind sie sicher?',
+  confirmButtonText: 'Bestätigen',
+  onConfirm: closePopconfirm,
+  onCancel: closePopconfirm,
+};
+
+const popConfirmState = $state<{ state: PopconfirmState }>({ state: defaultState});
+
+export function initializePopconfimContext() {
+  setContext(POPCONFIRM_CONTEXT, popConfirmState);
+};
+
+export function popconfirm(anchorElement: HTMLElement, onConfirm: () => void, options?: ConfirmOptions) {
+  popConfirmState.state = {
+    ...defaultState,
+    ...options,
+    anchorElement,
+    open: true,
+    onConfirm,
+  };
+};
+
+export function closePopconfirm() {
+  popConfirmState.state.open = false;
+};
+
+export function getPopconfirmState() {
+  return getContext<{ state: PopconfirmState }>(POPCONFIRM_CONTEXT).state;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
   import Header from '$lib/components/Header.svelte';
   import { setContext } from 'svelte';
+  import PopConfirm from '$lib/components/Popconfirm.svelte';
+  import { initializePopconfimContext } from '$lib/context/PopConfirmContex.svelte.js';
   let { children, data } = $props();
 
   setContext('user_token', data.token);
+  initializePopconfimContext();
+
 </script>
 
 <svelte:head>
   <title>GDI Berlin - Metadateneditor</title>
 </svelte:head>
+
+<PopConfirm />
 
 <div class="container">
   <Header />

--- a/src/theme/_smui-theme.scss
+++ b/src/theme/_smui-theme.scss
@@ -20,8 +20,11 @@
   $primary: #75b1d8,
   $secondary: #676778,
   $surface: #fff,
+  $on-primary: #000,
+  $on-secondary: #fff,
+  $on-surface: #000,
   $background: #fff,
-  $error: color-palette.$red-900
+  $error: #b71c1c
 );
 
 @use '@material/theme/styles';


### PR DESCRIPTION
This introduces the Popconfirm component.

It also contains some refactoring to move the FormContext into the `context` directory.
So reviewing the first commit only might be sufficent.

# Preview

![gdi-mde-popconfirm](https://github.com/user-attachments/assets/64be3b33-58d5-4ae9-bceb-71f8873a8f9e)
