### PR TITLE
Add readonly route with print button

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "yaml": "^2.7.0",
       },
       "devDependencies": {
+        "@smui/fab": "^8.0.0-beta.3",
         "@sveltejs/adapter-auto": "^3.3.1",
         "@sveltejs/kit": "^2.9.0",
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
@@ -153,6 +154,8 @@
     "@material/dom": ["@material/dom@14.0.0", "", { "dependencies": { "@material/feature-targeting": "^14.0.0", "tslib": "^2.1.0" } }, "sha512-8t88XyacclTj8qsIw9q0vEj4PI2KVncLoIsIMzwuMx49P2FZg6TsLjor262MI3Qs00UWAifuLMrhnOnfyrbe7Q=="],
 
     "@material/elevation": ["@material/elevation@14.0.0", "", { "dependencies": { "@material/animation": "^14.0.0", "@material/base": "^14.0.0", "@material/feature-targeting": "^14.0.0", "@material/rtl": "^14.0.0", "@material/theme": "^14.0.0", "tslib": "^2.1.0" } }, "sha512-Di3tkxTpXwvf1GJUmaC8rd+zVh5dB2SWMBGagL4+kT8UmjSISif/OPRGuGnXs3QhF6nmEjkdC0ijdZLcYQkepw=="],
+
+    "@material/fab": ["@material/fab@14.0.0", "", { "dependencies": { "@material/animation": "^14.0.0", "@material/dom": "^14.0.0", "@material/elevation": "^14.0.0", "@material/feature-targeting": "^14.0.0", "@material/focus-ring": "^14.0.0", "@material/ripple": "^14.0.0", "@material/rtl": "^14.0.0", "@material/shape": "^14.0.0", "@material/theme": "^14.0.0", "@material/tokens": "^14.0.0", "@material/touch-target": "^14.0.0", "@material/typography": "^14.0.0", "tslib": "^2.1.0" } }, "sha512-s4rrw2TLU8ITKopHSTEHuJEFsGEZsb+ijwW16pQt0h9GArxPGaALT+CCJIPjf75D3wPEEMW0vnLj7oMoII2VFg=="],
 
     "@material/feature-targeting": ["@material/feature-targeting@14.0.0", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-a5WGgHEq5lJeeNL5yevtgoZjBjXWy6+klfVWQEh8oyix/rMJygGgO7gEc52uv8fB8uAIoYEB3iBMOv8jRq8FeA=="],
 
@@ -289,6 +292,8 @@
     "@smui/common": ["@smui/common@8.0.0-beta.3", "", { "dependencies": { "@material/dom": "^14.0.0" } }, "sha512-j4XE0cGn1O4PgfAFyemNE6KQicnjOUnSb+gWD52GJntatBEhszz1GdaKUTIF4oxM/V7RW5nSX2xzrilPytLEwg=="],
 
     "@smui/dialog": ["@smui/dialog@8.0.0-beta.3", "", { "dependencies": { "@material/button": "^14.0.0", "@material/dialog": "^14.0.0", "@material/dom": "^14.0.0", "@smui/common": "^8.0.0-beta.3" } }, "sha512-bsOviW/jsSQwhBHOMjz+5iEpsaI2HZ6Baszp5Z1bVhgh+waVWcIZRTXV0TGLJEcQpian759Z7GaOkiaLFYsc6A=="],
+
+    "@smui/fab": ["@smui/fab@8.0.0-beta.3", "", { "dependencies": { "@material/fab": "^14.0.0", "@material/feature-targeting": "^14.0.0", "@smui/common": "^8.0.0-beta.3", "@smui/ripple": "^8.0.0-beta.3" } }, "sha512-Bw02W+SuyDNuxiPv7RvvGOXMsFkW/e+tF0DbqPoC9sDmx9Ivjt4mOSohxaqhlsfCWhJd5w+nHV1QsTEcSpO9yQ=="],
 
     "@smui/floating-label": ["@smui/floating-label@8.0.0-beta.3", "", { "dependencies": { "@material/floating-label": "^14.0.0", "@smui/common": "^8.0.0-beta.3" } }, "sha512-lZmvDahjla7JDKspF9tBUq2sFpeaK5R22f2WCQGOmAV39ygV68ZZg7jKcwqDJJlLLflZXDmISmS/O2GTZQRyvg=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "smui-theme-light": "smui-theme compile static/smui.css -i src/theme"
   },
   "devDependencies": {
+    "@smui/fab": "^8.0.0-beta.3",
     "@sveltejs/adapter-auto": "^3.3.1",
     "@sveltejs/kit": "^2.9.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",

--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -45,6 +45,7 @@
     display: flex;
     list-style: none;
     padding: 0;
+    margin: 0;
 
     i {
       color: gray;

--- a/src/lib/components/Form/ApprovalPanel.svelte
+++ b/src/lib/components/Form/ApprovalPanel.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import type { MetadataCollection } from '$lib/models/metadata';
+  import Paper from '@smui/paper';
+
+  type ApprovalPanelProps = {
+    metadata?: MetadataCollection;
+  };
+
+  let { metadata }: ApprovalPanelProps = $props();
+
+</script>
+
+<div class="approval-panel-container">
+  <Paper elevation={6} class="approval-panel">
+    <div class="approval-panel-content">
+      <h2>Freigabe {metadata?.isoMetadata?.title}</h2>
+      <div>TODO</div>
+  </Paper>
+</div>
+
+<style lang="scss">
+  .approval-panel-container {
+    position: fixed;
+    z-index: 1;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  :global(div.smui-paper.approval-panel) {
+    background-color: white;
+    padding: 0.5em 1em;
+  }
+
+  .approval-panel-content {
+    display: flex;
+    flex-direction: column;
+    min-width: 60vw;
+    min-height: 60vh;
+  }
+</style>

--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -31,6 +31,7 @@
     label={fieldConfig?.label}
     maxlength={500}
     onblur={onBlur}
+    input$rows={5}
     {validationResult}
   />
   <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -27,7 +27,7 @@ export type FieldConfig<T> = {
 
 const isDefined = (val: any) => val !== undefined && val !== null && val !== '';
 
-const isValidNumber = (val: string) => {
+const isValidPhoneNumber = (val: string) => {
   const numberRegex = /^[+]?[0-9\s]+$/;
   return numberRegex.test(val);
 };
@@ -100,12 +100,6 @@ export const FieldConfigs: FieldConfig<any>[] = [
           helpText: 'Bitte geben Sie ein Vorschaubild an.'
         };
       }
-      if (!val.endsWith('.png')) {
-        return {
-          valid: false,
-          helpText: 'Das Vorschaubild muss im PNG-Format sein.'
-        };
-      }
       return { valid: true };
     },
     section: 'basedata',
@@ -164,10 +158,10 @@ export const FieldConfigs: FieldConfig<any>[] = [
             index,
             subKey: 'phone'
           });
-        } else if (!isValidNumber(contact.phone!)) {
+        } else if (!isValidPhoneNumber(contact.phone!)) {
           validationResult.push({
             valid: false,
-            helpText: 'Bitte geben Sie eine gültige Telefonnummer an. (z.B. +49 123 456789)',
+            helpText: 'Bitte geben Sie eine gültige Telefonnummer an.',
             index,
             subKey: 'phone'
           });

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -41,6 +41,7 @@
   import Button, { Icon, Label } from '@smui/button';
   import ScrollToTopButton from './ScrollToTopButton.svelte';
   import HelpPanel from './HelpPanel.svelte';
+  import { page } from '$app/state';
 
   type FormProps = {
     metadata?: MetadataCollection;
@@ -54,6 +55,9 @@
     label: string;
     disabledCheck: (metadata?: MetadataCollection) => boolean;
   };
+
+  let commentsPanelVisible = $state(false);
+  let approvalPanelVisible = $state(false);
 
   const SECTIONS: SectionConfig[] = [
     {
@@ -101,6 +105,23 @@
     });
     await tick();
   };
+
+  $effect(() => {
+    const action = page.url.searchParams.get('action');
+
+    if (action?.includes('print')) {
+      print();
+    }
+
+    if(action?.includes('comments')) {
+      commentsPanelVisible = true;
+    }
+
+    if(action?.includes('approval')) {
+      approvalPanelVisible = true;
+    }
+
+  });
 </script>
 
 <div class="metadata-form">
@@ -176,7 +197,7 @@
     </form>
     <HelpPanel />
   </div>
-  <FormFooter {metadata}>
+  <FormFooter {metadata} {commentsPanelVisible} {approvalPanelVisible}>
     <Button
       class="previous-button"
       title="Zurück"

--- a/src/lib/components/Form/FormFooter.svelte
+++ b/src/lib/components/Form/FormFooter.svelte
@@ -41,8 +41,6 @@
       approvalPanelVisible = false;
     }
   };
-
-  $inspect(commentsPanelVisible);
 </script>
 
 <footer class="form-footer">

--- a/src/lib/components/Form/FormFooter.svelte
+++ b/src/lib/components/Form/FormFooter.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { allFieldsValid } from '$lib/context/FormContext.svelte';
   import type { MetadataCollection } from '$lib/models/metadata';
+  import ApprovalPanel from './ApprovalPanel.svelte';
   import CommentsPanel from './CommentsPanel.svelte';
   import Button, { Icon, Label } from '@smui/button';
   import type { Snippet } from 'svelte';
@@ -9,18 +10,39 @@
     metadata?: MetadataCollection;
     text?: string;
     children?: Snippet;
+    commentsPanelVisible?: boolean;
+    approvalPanelVisible?: boolean;
   };
 
-  let { metadata, children }: FormFooterProps = $props();
+  let {
+    metadata,
+    children,
+    commentsPanelVisible: commentsPanelVisibleProp,
+    approvalPanelVisible: approvalPanelVisibleProp,
+  }: FormFooterProps = $props();
 
   let commentsPanelVisible = $state(false);
+  let approvalPanelVisible = $state(false);
   let submitEnabled = $derived(allFieldsValid(metadata));
 
-  const closeCommentsPanel = (event: MouseEvent | KeyboardEvent) => {
+  $effect(() => {
+    commentsPanelVisible = commentsPanelVisibleProp ?? false;
+  });
+
+  $effect(() => {
+    approvalPanelVisible = approvalPanelVisibleProp ?? false;
+  });
+
+  const closePanels = (event: MouseEvent | KeyboardEvent) => {
     if (event.target instanceof Element && !event.target.closest('.comments-panel')) {
       commentsPanelVisible = false;
     }
+    if (event.target instanceof Element && !event.target.closest('.approval-panel')) {
+      approvalPanelVisible = false;
+    }
   };
+
+  $inspect(commentsPanelVisible);
 </script>
 
 <footer class="form-footer">
@@ -48,18 +70,26 @@
       <Icon class="material-icons">verified</Icon>
       <Label>Freigabe</Label>
     </Button>
-    {#if commentsPanelVisible}
-      <div
-        class="mask"
-        onclick={closeCommentsPanel}
-        onkeydown={closeCommentsPanel}
-        role="button"
-        tabindex="0"
-      ></div>
-      <CommentsPanel {metadata} />
-    {/if}
   </div>
 </footer>
+
+{#if commentsPanelVisible || approvalPanelVisible}
+  <div
+    class="mask"
+    onclick={closePanels}
+    onkeydown={closePanels}
+    role="button"
+    tabindex="0"
+  ></div>
+{/if}
+
+{#if commentsPanelVisible}
+  <CommentsPanel {metadata} />
+{/if}
+
+{#if approvalPanelVisible}
+  <ApprovalPanel {metadata} />
+{/if}
 
 <style lang="scss">
   footer.form-footer {
@@ -81,19 +111,19 @@
       }
     }
 
-    .mask {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(0, 0, 0, 0.25); /* Halbtransparent */
-      z-index: 1; /* Damit es über allem anderen liegt */
-    }
-
     .container {
       display: flex;
       padding: 0 1em;
     }
+  }
+
+  .mask {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.25);
+    z-index: 1;
   }
 </style>

--- a/src/lib/components/Form/Inputs/TextAreaInput.svelte
+++ b/src/lib/components/Form/Inputs/TextAreaInput.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Textfield from '@smui/textfield';
-  import CharacterCounter from '@smui/textfield/character-counter';
   import type { ComponentProps } from 'svelte';
   import type { ValidationResult } from '../FieldsConfig';
   import HelperText from '@smui/textfield/helper-text';
@@ -40,7 +39,9 @@
         {helpText}
       </HelperText>
       {#if maxlength}
-        <CharacterCounter />
+        <div class="mdc-text-field-character-counter">
+          {value.length} / {maxlength}
+        </div>
       {/if}
     {/snippet}
   </Textfield>
@@ -48,6 +49,11 @@
 
 <style lang="scss">
   .text-area-input {
+    :global(.mdc-floating-label) {
+      background-color: white;
+      color: var(--title-color);
+    }
+
     :global(.mdc-text-field-helper-text.valid) {
       color: var(--mdc-theme-text-primary-on-background);
     }

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -5,7 +5,7 @@
   let { text = 'Metadaten Editor' } = $props();
 </script>
 
-<header>
+<header class="application-header">
   <div class="left-items">
     <Breadcrumbs />
   </div>
@@ -18,7 +18,7 @@
 </header>
 
 <style>
-  header {
+  header.application-header {
     background-color: #f8f9fa;
     height: 3em;
     text-align: center;

--- a/src/lib/components/MetadataCard.svelte
+++ b/src/lib/components/MetadataCard.svelte
@@ -6,6 +6,7 @@
   import type { Token } from '$lib/models/keycloak';
   import RoleTag from './RoleTag.svelte';
   import type { MetadataCollection } from '$lib/models/metadata';
+  import { popconfirm } from '$lib/context/PopConfirmContex.svelte';
 
   const FALLBACK_IMAGE =
     'https://www.berlin.de/css/berlin_de/foxtrot/images/logo_berlin_m_srgb.svg';
@@ -42,6 +43,21 @@
       body: JSON.stringify({ userId })
     });
   };
+
+  async function onDelete(evt: MouseEvent) {
+    const targetEl = evt.currentTarget as HTMLElement;
+    evt.preventDefault();
+    popconfirm(
+      targetEl,
+      async () => {
+        // TODO:
+      },
+      {
+        text: 'Löschen ist noch nicht implementiert',
+        confirmButtonText: 'Ok'
+      }
+    );
+  }
 </script>
 
 <Card class="metadata-card">
@@ -65,6 +81,30 @@
     {/if}
     <IconButton
       toggle
+      aria-label={'Metadatensatz Löschen'}
+      title={'Metadatensatz Löschen'}
+      onclick={onDelete}
+    >
+      <Icon class="material-icons">delete</Icon>
+    </IconButton>
+    <IconButton
+      toggle
+      aria-label={'Kommentare anzeigen'}
+      title={'Kommentare anzeigen'}
+      onclick={() => goto(`/metadata/${metadata.metadataId}/?action=comments`)}
+    >
+      <Icon class="material-icons">chat</Icon>
+    </IconButton>
+    <IconButton
+      toggle
+      aria-label={'Drucken'}
+      title={'Drucken'}
+      onclick={() => goto(`/metadata/${metadata.metadataId}/readonly?action=print`)}
+    >
+      <Icon class="material-icons">print</Icon>
+    </IconButton>
+    <IconButton
+      toggle
       aria-label={assignedToMe
         ? 'Mir zugewiesen.\nKlicken um Zuordnung zu entfernen.'
         : 'Mir zuweisen'}
@@ -72,8 +112,8 @@
       onclick={assignedToMe ? removeAssignment : assignToMe}
       pressed={assignedToMe}
     >
-      <Icon class="material-icons-filled assigned-to-me" on>assignment_ind</Icon>
-      <Icon class="material-icons">assignment_add</Icon>
+      <Icon class="material-icons-filled assigned-to-me" on>person_edit</Icon>
+      <Icon class="material-icons">person_edit</Icon>
     </IconButton>
   </ActionIcons>
 </Card>
@@ -102,6 +142,10 @@
     :global(.metadata-card-content) {
       height: 15rem;
       text-align: center;
+    }
+
+    :global(.metadata-card-actions) {
+      justify-content: space-around;
     }
 
     :global(.assigned-to-me) {

--- a/src/lib/components/ReadOnly/MetadataDisplay.svelte
+++ b/src/lib/components/ReadOnly/MetadataDisplay.svelte
@@ -17,68 +17,74 @@
 </script>
 
 <div class="metadata-display">
-  <section id="basedata">
-    <h2>1. Basisangaben</h2>
-    <DisplayField key="isoMetadata.title" />
-    <DisplayField key="isoMetadata.description" />
-    <DisplayField key="isoMetadata.keywords" />
-    <DisplayField key="isoMetadata.preview" />
-    <DisplayField key="isoMetadata.contacts" />
-  </section>
-  <section id="classification">
-    <h2>2. Einordnung</h2>
-    <DisplayField key="isoMetadata.metadataProfile" />
-    <DisplayField key="clientMetadata.privacy" />
-    <DisplayField key="isoMetadata.termsOfUse" />
-    <DisplayField key="isoMetadata.annexTheme" />
-    <DisplayField key="isoMetadata.qualityReportCheck" />
-    <DisplayField key="clientMetadata.highValueDataset" />
-    <DisplayField key="isoMetadata.topicCategory" />
-  </section>
-  <section id="temp_and_spatial">
-    <h2>3. Zeitliche und Räumliche Angaben</h2>
-    <DisplayField key="isoMetadata.created" />
-    <DisplayField key="isoMetadata.published" />
-    <DisplayField key="isoMetadata.maintenanceFrequency" />
-    <DisplayField key="isoMetadata.lastUpdated" />
-    <DisplayField key="isoMetadata.validityRange" />
-    <DisplayField key="isoMetadata.deliveredCoordinateSystem" />
-    <DisplayField key="isoMetadata.coordinateSystem" />
-    <DisplayField key="isoMetadata.extent" />
-    <DisplayField key="isoMetadata.resolution" />
-  </section>
-  <section id="additional">
-    <h2>4. Weitere Angaben</h2>
-    <DisplayField key="isoMetadata.contentDescription" />
-    <DisplayField key="isoMetadata.technicalDescription" />
-    <DisplayField key="isoMetadata.lineage" />
-    <DisplayField key="isoMetadata.additionalInformation" />
-  </section>
-  <section id="services">
-    <h2>5. Dienste</h2>
-    <DisplayField key="isoMetadata.services" />
-  </section>
+  <div class="content">
+    <section id="basedata">
+      <h2>1. Basisangaben</h2>
+      <DisplayField key="isoMetadata.title" />
+      <DisplayField key="isoMetadata.description" />
+      <DisplayField key="isoMetadata.keywords" />
+      <DisplayField key="isoMetadata.preview" />
+      <DisplayField key="isoMetadata.contacts" />
+    </section>
+    <section id="classification">
+      <h2>2. Einordnung</h2>
+      <DisplayField key="isoMetadata.metadataProfile" />
+      <DisplayField key="clientMetadata.privacy" />
+      <DisplayField key="isoMetadata.termsOfUse" />
+      <DisplayField key="isoMetadata.annexTheme" />
+      <DisplayField key="isoMetadata.qualityReportCheck" />
+      <DisplayField key="clientMetadata.highValueDataset" />
+      <DisplayField key="isoMetadata.topicCategory" />
+    </section>
+    <section id="temp_and_spatial">
+      <h2>3. Zeitliche und Räumliche Angaben</h2>
+      <DisplayField key="isoMetadata.created" />
+      <DisplayField key="isoMetadata.published" />
+      <DisplayField key="isoMetadata.maintenanceFrequency" />
+      <DisplayField key="isoMetadata.lastUpdated" />
+      <DisplayField key="isoMetadata.validityRange" />
+      <DisplayField key="isoMetadata.deliveredCoordinateSystem" />
+      <DisplayField key="isoMetadata.coordinateSystem" />
+      <DisplayField key="isoMetadata.extent" />
+      <DisplayField key="isoMetadata.resolution" />
+    </section>
+    <section id="additional">
+      <h2>4. Weitere Angaben</h2>
+      <DisplayField key="isoMetadata.contentDescription" />
+      <DisplayField key="isoMetadata.technicalDescription" />
+      <DisplayField key="isoMetadata.lineage" />
+      <DisplayField key="isoMetadata.additionalInformation" />
+    </section>
+    <section id="services">
+      <h2>5. Dienste</h2>
+      <DisplayField key="isoMetadata.services" />
+    </section>
+  </div>
 </div>
 
 <style lang="scss">
   .metadata-display {
-    width: 80%;
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 2em;
-    padding: 1em;
+    overflow: auto;
 
-    section {
-      display: flex;
-      flex-direction: column;
-      gap: 1em;
-      padding: 1em;
-    }
+    .content {
+      width: 80%;
 
-    h2 {
-      margin-top: 0;
-      font-size: 1.5em;
-      color: #333;
+      section {
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+        padding: 1em;
+      }
+
+      h2 {
+        margin-top: 0;
+        font-size: 1.5em;
+        color: #333;
+      }
     }
   }
 </style>

--- a/src/lib/components/ReadOnly/MetadataDisplay.svelte
+++ b/src/lib/components/ReadOnly/MetadataDisplay.svelte
@@ -14,8 +14,6 @@
   if (metadata) {
     setFormData(metadata);
   }
-
-  $inspect(metadata);
 </script>
 
 <div class="metadata-display">

--- a/src/routes/metadata/[metadataid]/+page.svelte
+++ b/src/routes/metadata/[metadataid]/+page.svelte
@@ -2,13 +2,8 @@
   import { page } from '$app/state';
   import Form from '$lib/components/Form/Form.svelte';
   import { setFormData } from '$lib/context/FormContext.svelte';
-  import { getContext } from 'svelte';
-  import { getHighestRole } from '$lib/util.js';
-  import type { Token } from '$lib/models/keycloak.js';
-  import MetadataDisplay from '$lib/components/ReadOnly/MetadataDisplay.svelte';
 
   const activeSection = page.url.hash.slice(1) || 'basedata';
-  const readOnlyParam = page.url.searchParams.get('readOnly') === 'true';
 
   let { data } = $props();
   const metadata = $derived(data.metadata);
@@ -16,19 +11,11 @@
   $effect(() => {
     setFormData(metadata);
   });
-
-  const token = getContext<Token>('user_token');
-
-  const readOnly = $derived(getHighestRole(token) === 'QualityAssurance' || readOnlyParam);
 </script>
 
 <div class="metadata">
   <h1>{metadata.isoMetadata.title}</h1>
-  {#if readOnly}
-    <MetadataDisplay {metadata} />
-  {:else}
-    <Form {metadata} {activeSection} />
-  {/if}
+  <Form {metadata} {activeSection} />
 </div>
 
 <style lang="scss">

--- a/src/routes/metadata/[metadataid]/readonly/+page.server.ts
+++ b/src/routes/metadata/[metadataid]/readonly/+page.server.ts
@@ -1,19 +1,11 @@
 import { error } from '@sveltejs/kit';
 import { getMetadataCollectionByMetadataId } from '$lib/api/metadata.js';
-import { getAccessToken, parseToken } from '$lib/auth/cookies.js';
-import { getHighestRole } from '$lib/util';
+import { getAccessToken } from '$lib/auth/cookies.js';
 import { redirect } from '@sveltejs/kit';
 
-export async function load({ params, cookies, url }) {
+export async function load({ params, cookies }) {
   const token = await getAccessToken(cookies);
   if (!token) return redirect(302, '/login');
-
-  const parsedToken = parseToken(token);
-  const readOnly = getHighestRole(parsedToken) === 'QualityAssurance';
-
-  if (readOnly) {
-    return redirect(302, url + '/readonly');
-  }
 
   const metadata = await getMetadataCollectionByMetadataId(params.metadataid, token);
   if (!metadata) return error(404, `Metadata with ID ${params.metadataid} could not be found`);

--- a/src/routes/metadata/[metadataid]/readonly/+page.svelte
+++ b/src/routes/metadata/[metadataid]/readonly/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Fab, { Icon } from '@smui/fab';
   import { browser } from '$app/environment';
   import MetadataDisplay from '$lib/components/ReadOnly/MetadataDisplay.svelte';
 
@@ -15,17 +16,33 @@
 </script>
 
 <div class="readonly-metadata">
-  <button
+  <Fab
+    title="Drucken"
     class="print-button"
     onclick={onPrintClick}
   >
-    Drucken
-  </button>
+    <Icon class="material-icons">
+      print
+    </Icon>
+  </Fab>
   <h1>{metadata?.isoMetadata?.title}</h1>
   <MetadataDisplay {metadata} />
 </div>
 
 <style lang="scss">
+  .readonly-metadata {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    :global(.print-button) {
+      position: fixed;
+      top: 5em;
+      left: 1.5em;
+      background-color: var(--primary-color);
+    }
+  }
+
   @media print {
     :global(html, body, main) {
       overflow: visible !important;
@@ -34,7 +51,7 @@
     :global(header.application-header) {
       display: none !important;
     }
-    button.print-button {
+    :global(.print-button) {
       display: none;
     }
   }
@@ -42,11 +59,5 @@
   @page {
     size: A4;
     margin: 20mm;
-  }
-
-  .readonly-metadata {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
   }
 </style>

--- a/src/routes/metadata/[metadataid]/readonly/+page.svelte
+++ b/src/routes/metadata/[metadataid]/readonly/+page.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import MetadataDisplay from '$lib/components/ReadOnly/MetadataDisplay.svelte';
+
+  const { data } = $props();
+
+  const metadata = $derived(data.metadata);
+
+  const onPrintClick = () => {
+    if (browser) {
+      window.print();
+    }
+  };
+
+</script>
+
+<div class="readonly-metadata">
+  <button
+    class="print-button"
+    onclick={onPrintClick}
+  >
+    Drucken
+  </button>
+  <h1>{metadata?.isoMetadata?.title}</h1>
+  <MetadataDisplay {metadata} />
+</div>
+
+<style lang="scss">
+  @media print {
+    :global(html, body, main) {
+      overflow: visible !important;
+    }
+
+    :global(header.application-header) {
+      display: none !important;
+    }
+    button.print-button {
+      display: none;
+    }
+  }
+
+  @page {
+    size: A4;
+    margin: 20mm;
+  }
+
+  .readonly-metadata {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+</style>

--- a/src/routes/metadata/[metadataid]/readonly/+page.svelte
+++ b/src/routes/metadata/[metadataid]/readonly/+page.svelte
@@ -2,16 +2,37 @@
   import Fab, { Icon } from '@smui/fab';
   import { browser } from '$app/environment';
   import MetadataDisplay from '$lib/components/ReadOnly/MetadataDisplay.svelte';
+  import { page } from '$app/state';
+  import FormFooter from '../../../../lib/components/Form/FormFooter.svelte';
 
   const { data } = $props();
+  let commentsPanelVisible = $state(false);
+  let approvalPanelVisible = $state(false);
 
   const metadata = $derived(data.metadata);
 
-  const onPrintClick = () => {
+  const print = () => {
     if (browser) {
       window.print();
     }
   };
+
+  $effect(() => {
+    const action = page.url.searchParams.get('action');
+
+    if (action?.includes('print')) {
+      print();
+    }
+
+    if(action?.includes('comments')) {
+      commentsPanelVisible = true;
+    }
+
+    if(action?.includes('approval')) {
+      approvalPanelVisible = true;
+    }
+
+  });
 
 </script>
 
@@ -19,7 +40,7 @@
   <Fab
     title="Drucken"
     class="print-button"
-    onclick={onPrintClick}
+    onclick={print}
   >
     <Icon class="material-icons">
       print
@@ -27,13 +48,21 @@
   </Fab>
   <h1>{metadata?.isoMetadata?.title}</h1>
   <MetadataDisplay {metadata} />
+  <FormFooter
+    {metadata}
+    {commentsPanelVisible}
+    {approvalPanelVisible}
+  />
 </div>
 
 <style lang="scss">
   .readonly-metadata {
     display: flex;
     flex-direction: column;
-    align-items: center;
+
+    h1 {
+      text-align: center;
+    }
 
     :global(.print-button) {
       position: fixed;
@@ -48,12 +77,22 @@
       overflow: visible !important;
     }
 
-    :global(header.application-header) {
+    :global(header.application-header),
+    :global(footer.form-footer),
+    :global(.print-button)
+    {
       display: none !important;
     }
-    :global(.print-button) {
-      display: none;
+
+    :global(.metadata-display) {
+      overflow: visible !important;
     }
+
+    :global(.metadata-display .content) {
+      width: 100% !important;
+      overflow: visible !important;
+    }
+
   }
 
   @page {

--- a/src/theme/_smui-theme.scss
+++ b/src/theme/_smui-theme.scss
@@ -30,13 +30,23 @@
 @use '@material/theme/styles';
 
 :root {
-  --primary-color: #75b1d8;
+  --primary-color: hsl(204, 56%, 65%);
   --secondary-color: #676778;
   --surface-color: #fff;
   --background-color: #fff;
   --error-color: #b71c1c;
   --chat-other-color: #ffd3d3;
   --chat-self-color: #cdffdd;
+
+  --link-color: #40b3ff;
+
+  --primary-10: hsl(204, 56%, 10%);
+  --primary-30: hsl(204, 56%, 30%);
+  --primary-50: hsl(204, 56%, 50%);
+  --primary-70: hsl(204, 56%, 70%);
+  --primary-90: hsl(204, 56%, 90%);
+
+  --title-color: var(--primary-10);
 }
 
 html,
@@ -46,7 +56,7 @@ body {
 }
 
 a {
-  color: #40b3ff;
+  color: var(--link-color);
 }
 
 a:visited {


### PR DESCRIPTION
This adds the `readonly` subroute to metadata. If a user does not have the permission to edit he will automatically be redirected to the `readonly` route.

This also fixes some minor issues:

- Description field layout bugs (strikethrough label, rows, initial character count)
- preview validation
- phonenumber validation

