### PR TITLE
This adds and updates some form fields

### DIFF
--- a/src/lib/components/Form/Field/05_MetadataProfile.svelte
+++ b/src/lib/components/Form/Field/05_MetadataProfile.svelte
@@ -35,7 +35,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue?: string) => {
-    // TODO check if value has changed
     const response = await persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/13_TopicCategory.svelte
+++ b/src/lib/components/Form/Field/13_TopicCategory.svelte
@@ -3,7 +3,6 @@
   import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import SelectInput from '../Inputs/SelectInput.svelte';
-  import AutoFillButton from '../AutoFillButton.svelte';
   import type { IsoTheme } from '$lib/models/metadata';
   import type { ValidationResult } from '../FieldsConfig';
 
@@ -19,6 +18,10 @@
     if (valueFromData) {
       value = valueFromData;
     }
+  });
+
+  $effect(() => {
+    getAutoFillValues(inspireTheme);
   });
 
   let showCheckmark = $state(false);
@@ -41,11 +44,11 @@
     }));
   };
 
-  const getAutoFillValues = async () => {
-    if (!inspireTheme) return;
+  const getAutoFillValues = async (inspireID?: string) => {
+    if (!inspireID) return;
     const response = await fetch(`/data/iso_themes`);
     const data = await response.json();
-    const match = data.find((entry: IsoTheme) => entry.inspireID === inspireTheme);
+    const match = data.find((entry: IsoTheme) => entry.inspireID === inspireID);
     if (!match) return;
     value = match.isoID;
     onChange(value);
@@ -61,17 +64,14 @@
         key={KEY}
         label={fieldConfig?.label}
         options={OPTIONS}
+        disabled={!!inspireTheme}
         {value}
         {onChange}
         {validationResult}
       />
     {/await}
   </Paper>
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
-    {#if inspireTheme}
-      <AutoFillButton onclick={getAutoFillValues} />
-    {/if}
-  </FieldTools>
+  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -15,7 +15,7 @@
   let contacts = $state<ContactListEntry[]>([]);
   const valueFromData = $derived(getValue<Contacts>(KEY));
   $effect(() => {
-    if (valueFromData) {
+    if (valueFromData && valueFromData.length > 0) {
       contacts =
         valueFromData?.map((contact) => {
           const listId = (Math.floor(Math.random() * 1000000) + Date.now()).toString(36);
@@ -27,6 +27,16 @@
             email: contact.email || ''
           };
         }) || [];
+    } else {
+      contacts = [
+        {
+          listId: Date.now().toString(36),
+          name: '',
+          organisation: '',
+          phone: '',
+          email: ''
+        }
+      ];
     }
   });
 

--- a/src/lib/components/Form/Field/24_TermsOfUseField.svelte
+++ b/src/lib/components/Form/Field/24_TermsOfUseField.svelte
@@ -61,7 +61,7 @@
             disabled: !item.active
           })
         )}
-        bind:value
+        value={value.toString()}
         {onChange}
         {validationResult}
       />

--- a/src/lib/components/Form/Field/30_ContentDescription.svelte
+++ b/src/lib/components/Form/Field/30_ContentDescription.svelte
@@ -1,134 +1,48 @@
 <script lang="ts">
-  import IconButton from '@smui/icon-button';
+  import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
+  import Paper from '@smui/paper';
   import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
-  import TextInput from '../Inputs/TextInput.svelte';
   import FieldTools from '../FieldTools.svelte';
-  import type { ContentDescription } from '$lib/models/metadata';
 
-  type ContentDescriptionListEntry = ContentDescription & { listId: string };
+  const KEY = 'isoMetadata.contentDescription';
 
-  const KEY = 'isoMetadata.UNKNOWN';
-
-  const valueFromData = $derived(getValue<ContentDescription[]>(KEY));
-  let values = $state<ContentDescriptionListEntry[]>([]);
+  const valueFromData = $derived(getValue<string>(KEY));
+  let value = $state<string>('');
   $effect(() => {
     if (valueFromData) {
-      values = valueFromData?.map((description) => {
-        const listId = (Math.floor(Math.random() * 1000000) + Date.now()).toString(36);
-        return {
-          listId,
-          url: description.url || '',
-          description: description.description || '',
-          code: 'information'
-        };
-      });
+      value = valueFromData;
     }
   });
-
   let showCheckmark = $state(false);
-  const fieldConfig = getFieldConfig<ContentDescription[]>(KEY);
+  const fieldConfig = getFieldConfig<string>(KEY);
 
-  const persist = async () => {
-    const response = await persistValue(
-      KEY,
-      values.map(
-        (contentDescription) =>
-          ({
-            description: contentDescription.description,
-            url: contentDescription.url,
-            code: 'information'
-          }) satisfies ContentDescription
-      )
-    );
+  const onBlur = async () => {
+    const response = await persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;
     }
   };
-
-  const addItem = () => {
-    const listId = Date.now().toString(36);
-    values = [
-      {
-        listId,
-        url: '',
-        description: '',
-        code: 'information'
-      },
-      ...values
-    ];
-  };
-
-  const removeItem = (listId: string) => {
-    // TODO: add popconfirm
-    values = values.filter((contentDescription) => contentDescription.listId !== listId);
-    persist();
-  };
 </script>
 
-<div class="content-description-field">
-  <fieldset>
-    <legend
-      >{fieldConfig?.label || 'TODO: Inhaltliche Beschreibung'}
-      <IconButton
-        class="material-icons"
-        onclick={() => addItem()}
-        size="button"
-        title="Quelle hinzufügen"
-      >
-        add
-      </IconButton>
-    </legend>
-    {#each values as contentDescription (contentDescription.listId)}
-      <fieldset class="contentDescription">
-        <legend>
-          <IconButton
-            class="material-icons"
-            onclick={() => removeItem(contentDescription.listId)}
-            size="button"
-            title="Quelle entfernen"
-          >
-            delete
-          </IconButton>
-        </legend>
-        <TextInput
-          bind:value={contentDescription.url}
-          key={KEY}
-          label="URL (Dokument oder Website)"
-          onblur={persist}
-        />
-        <TextInput
-          bind:value={contentDescription.description}
-          key={KEY}
-          label="Beschreibung der Quelle"
-          onblur={persist}
-        />
-      </fieldset>
-    {/each}
-  </fieldset>
+<div class="technical-description-field">
+  <Paper>
+    <TextInput
+      bind:value
+      label={fieldConfig?.label || 'TODO: Technische Beschreibung'}
+      onblur={onBlur}
+    />
+  </Paper>
   <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">
-  .content-description-field {
+  .technical-description-field {
     position: relative;
     display: flex;
     gap: 0.25em;
 
-    fieldset {
+    :global(.smui-paper) {
       flex: 1;
-      border-radius: 4px;
-
-      > legend {
-        display: flex;
-        align-items: center;
-        font-size: 0.75em;
-      }
-    }
-
-    .contentDescription {
-      legend {
-        text-align: right;
-      }
     }
 
     :global(.mdc-text-field) {

--- a/src/lib/components/Form/Field/30_ContentDescription.svelte
+++ b/src/lib/components/Form/Field/30_ContentDescription.svelte
@@ -28,7 +28,7 @@
   <Paper>
     <TextInput
       bind:value
-      label={fieldConfig?.label || 'TODO: Technische Beschreibung'}
+      label={fieldConfig?.label}
       onblur={onBlur}
     />
   </Paper>

--- a/src/lib/components/Form/Field/31_TechnicalDescription.svelte
+++ b/src/lib/components/Form/Field/31_TechnicalDescription.svelte
@@ -28,7 +28,7 @@
   <Paper>
     <TextInput
       bind:value
-      label={fieldConfig?.label || 'TODO: Technische Beschreibung'}
+      label={fieldConfig?.label}
       onblur={onBlur}
     />
   </Paper>

--- a/src/lib/components/Form/Field/31_TechnicalDescription.svelte
+++ b/src/lib/components/Form/Field/31_TechnicalDescription.svelte
@@ -4,10 +4,9 @@
   import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
 
-  const KEY = 'isoMetadata.UNKNOWN';
+  const KEY = 'isoMetadata.technicalDescription';
 
-  // TODO: check why this is a List on the server
-  const valueFromData = $derived(getValue<string>(KEY)?.[0]);
+  const valueFromData = $derived(getValue<string>(KEY));
   let value = $state<string>('');
   $effect(() => {
     if (valueFromData) {

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -86,7 +86,7 @@
 <div class="lineages-field">
   <fieldset>
     <legend
-      >{fieldConfig?.label || 'TODO: Herkunft der Daten'}
+      >{fieldConfig?.label}
       <IconButton
         class="material-icons"
         onclick={(evt) => addItem(evt)}

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -9,22 +9,31 @@
 
   type LineageListEntry = Lineage & { listId: string };
 
-  const KEY = 'isoMetadata.UNKNOWN';
+  const KEY = 'isoMetadata.lineage';
 
   const valueFromData = $derived(getValue<Lineage[]>(KEY));
   let lineages = $state<LineageListEntry[]>([]);
 
   $effect(() => {
-    if (valueFromData) {
+    if (valueFromData && valueFromData.length > 0) {
       lineages = valueFromData?.map((lineage) => {
-        const listId = (Math.floor(Math.random() * 1000000) + Date.now()).toString(36);
+        const listId = Date.now().toString(36);
         return {
           listId,
           title: lineage.title || '',
-          source: lineage.source || '',
-          publishDate: lineage.publishDate || ''
+          identifier: lineage.identifier || '',
+          date: lineage.date ? new Date(lineage.date).toISOString().split('T')[0] : ''
         };
       });
+    } else {
+      lineages = [
+        {
+          listId: Date.now().toString(36),
+          title: '',
+          identifier: '',
+          date: new Date().toISOString().split('T')[0]
+        }
+      ];
     }
   });
 
@@ -34,8 +43,8 @@
   const persistLineages = async () => {
     const value = lineages.map((lineage) => ({
       title: lineage.title,
-      source: lineage.source,
-      publishDate: lineage.publishDate
+      identifier: lineage.identifier,
+      date: lineage.date ? new Date(lineage.date).toISOString() : ''
     }));
     const response = await persistValue(KEY, value);
     if (response.ok) {
@@ -50,8 +59,8 @@
       {
         listId,
         title: '',
-        source: '',
-        publishDate: ''
+        identifier: '',
+        date: ''
       },
       ...lineages
     ];
@@ -109,14 +118,14 @@
         <div class="inline-fields">
           <DateInput
             class="publish-date-field"
-            bind:value={lineage.publishDate}
+            bind:value={lineage.date}
             key={KEY}
             label="Veröffentlichungsdatum"
             onblur={persistLineages}
           />
           <TextInput
             class="lineage-source-field"
-            bind:value={lineage.source}
+            bind:value={lineage.identifier}
             key={KEY}
             label="Identifier"
             onblur={persistLineages}
@@ -133,7 +142,6 @@
   .lineages-field {
     position: relative;
     display: flex;
-    align-items: center;
     gap: 0.25em;
 
     fieldset {

--- a/src/lib/components/Form/Field/38_InspireAnnexVersionField.svelte
+++ b/src/lib/components/Form/Field/38_InspireAnnexVersionField.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
+  import Paper from '@smui/paper';
+  import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
+  import FieldTools from '../FieldTools.svelte';
+  import type { ValidationResult } from '../FieldsConfig';
+
+  const KEY = 'isoMetadata.inspireAnnexVersion';
+  const PROFILE_KEY = 'isoMetadata.metadataProfile';
+
+  const { metadata } = $props();
+
+  const valueFromData = $derived(getValue<string>(KEY));
+  let value = $state('');
+  $effect(() => {
+    value = valueFromData || '';
+  });
+
+  let metadataProfile = $derived(getValue<string>(PROFILE_KEY, metadata));
+
+  let showCheckmark = $state(false);
+  const fieldConfig = getFieldConfig<string>(KEY);
+  let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+
+  const onBlur = async () => {
+    const response = await persistValue(KEY, value);
+    if (response.ok) {
+      showCheckmark = true;
+    }
+  };
+
+</script>
+
+{#if metadataProfile === 'INSPIRE_HARMONISED'}
+  <div class="inspire-annex-version-field">
+    <Paper class="input-wrapper">
+      <TextInput bind:value key={KEY} label={fieldConfig?.label} onblur={onBlur} {validationResult} />
+    </Paper>
+    <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  </div>
+{/if}
+
+<style lang="scss">
+  .inspire-annex-version-field {
+    position: relative;
+    display: flex;
+    gap: 0.25em;
+
+    :global(.input-wrapper) {
+      flex: 1;
+    }
+
+    :global(.mdc-text-field) {
+      display: flex;
+    }
+  }
+</style>

--- a/src/lib/components/Form/Field/39_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/39_AdditionalInformation.svelte
@@ -85,7 +85,7 @@
 <div class="contentDescriptions-field">
   <fieldset>
     <legend
-      >{fieldConfig?.label || 'TODO: Herkunft der Daten'}
+      >{fieldConfig?.label}
       <IconButton
         class="material-icons"
         onclick={(evt) => addItem(evt)}

--- a/src/lib/components/Form/Field/39_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/39_AdditionalInformation.svelte
@@ -3,86 +3,123 @@
   import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
   import TextInput from '../Inputs/TextInput.svelte';
   import FieldTools from '../FieldTools.svelte';
+  import { popconfirm } from '$lib/context/PopConfirmContex.svelte';
+  import type { ContentDescription } from '../../../models/metadata';
 
-  type AdditionalInformationListEntry = {
-    listId: string;
-    value: string;
-  };
+  type ContentDescriptionListEntry = ContentDescription & { listId: string };
 
-  const KEY = 'isoMetadata.UNKNOWN';
+  const KEY = 'isoMetadata.contentDescriptions';
 
-  const valueFromData = $derived(getValue<string[]>(KEY));
-  let values = $state<AdditionalInformationListEntry[]>([]);
+  const valueFromData = $derived(getValue<ContentDescription[]>(KEY));
+  let contentDescriptions = $state<ContentDescriptionListEntry[]>([]);
+
   $effect(() => {
-    if (valueFromData) {
-      values = valueFromData?.map((value) => {
-        const listId = (Math.floor(Math.random() * 1000000) + Date.now()).toString(36);
+    if (valueFromData && valueFromData.length > 0) {
+      contentDescriptions = valueFromData?.map((contentDescription) => {
+        const listId = contentDescription.url + contentDescription.description + Date.now().toString(36);
         return {
           listId,
-          value
+          code: 'information',
+          description: contentDescription.description || '',
+          url: contentDescription.url || ''
         };
       });
+    } else {
+      contentDescriptions = [
+        {
+          listId: Date.now().toString(36),
+          code: 'information',
+          description: '',
+          url: ''
+        }
+      ];
     }
   });
 
   let showCheckmark = $state(false);
-  const fieldConfig = getFieldConfig<string[]>(KEY);
+  const fieldConfig = getFieldConfig<ContentDescription[]>(KEY);
 
-  const persist = async () => {
-    const response = await persistValue(KEY, values);
+  const persistContentDescriptions = async () => {
+    const value = contentDescriptions.map((contentDescription) => ({
+      description: contentDescription.description,
+      url: contentDescription.url,
+      code: 'information'
+    }));
+    const response = await persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;
     }
   };
 
-  const addItem = () => {
+  const addItem = (evt: MouseEvent) => {
+    evt.preventDefault();
     const listId = Date.now().toString(36);
-    values = [
+    contentDescriptions = [
       {
         listId,
-        value: ''
+        code: 'information',
+        description: '',
+        url: ''
       },
-      ...values
+      ...contentDescriptions
     ];
   };
 
-  const removeItem = (listId: string) => {
-    // TODO: add popconfirm
-    values = values.filter((contact) => contact.listId !== listId);
-    persist();
+  const removeItem = (listId: string, evt: MouseEvent) => {
+    const targetEl = evt.currentTarget as HTMLElement;
+    evt.preventDefault();
+    popconfirm(
+      targetEl,
+      async () => {
+        contentDescriptions = contentDescriptions.filter((contentDescription) => contentDescription.listId !== listId);
+        persistContentDescriptions();
+      },
+      {
+        text: 'Möchten Sie diese Datengrundlage wirklich löschen?',
+        confirmButtonText: 'Löschen'
+      }
+    );
   };
 </script>
 
-<div class="content-description-field">
+<div class="contentDescriptions-field">
   <fieldset>
     <legend
-      >{fieldConfig?.label || 'TODO: Weitere Informationen'}
+      >{fieldConfig?.label || 'TODO: Herkunft der Daten'}
       <IconButton
         class="material-icons"
-        onclick={() => addItem()}
+        onclick={(evt) => addItem(evt)}
         size="button"
-        title="Quelle hinzufügen"
+        title="Kontakt hinzufügen"
       >
         add
       </IconButton>
     </legend>
-    {#each values as contact (contact.listId)}
-      <fieldset class="contact">
+    {#each contentDescriptions as contentDescription (contentDescription.listId)}
+      <fieldset class="contentDescription">
         <legend>
           <IconButton
             class="material-icons"
-            onclick={() => removeItem(contact.listId)}
+            onclick={(evt) => removeItem(contentDescription.listId, evt)}
             size="button"
-            title="Quelle entfernen"
+            title="Kontakt entfernen"
           >
             delete
           </IconButton>
         </legend>
         <TextInput
-          bind:value={contact.value}
+          bind:value={contentDescription.description}
           key={KEY}
-          label="URL (Dokument oder Website)"
-          onblur={persist}
+          label="Titel"
+          onblur={persistContentDescriptions}
+          required
+        />
+        <TextInput
+          bind:value={contentDescription.url}
+          key={KEY}
+          label="Url"
+          onblur={persistContentDescriptions}
+          required
         />
       </fieldset>
     {/each}
@@ -91,10 +128,9 @@
 </div>
 
 <style lang="scss">
-  .content-description-field {
+  .contentDescriptions-field {
     position: relative;
     display: flex;
-    align-items: center;
     gap: 0.25em;
 
     fieldset {
@@ -108,7 +144,7 @@
       }
     }
 
-    .contact {
+    .contentDescription {
       legend {
         text-align: right;
       }

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -237,6 +237,17 @@ export const FieldConfigs: FieldConfig<any>[] = [
     required: true
   },
   {
+    profile_id: 38,
+    label: 'Schema-Version des INSPIRE Themas',
+    key: 'isoMetadata.inspireAnnexVersion',
+    validator: () => {
+      // Optional
+      return { valid: true };
+    },
+    section: 'classification',
+    required: true
+  },
+  {
     profile_id: 37,
     label: 'Überprüfung des Qualitätsberichts',
     key: 'isoMetadata.valid',

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -499,7 +499,7 @@ export const FieldConfigs: FieldConfig<any>[] = [
   {
     profile_id: 31,
     label: 'Technische Beschreibung',
-    key: 'technicalMetadata.descriptions',
+    key: 'isoMetadata.technicalDescription',
     validator: (val: any) => {
       if (!isDefined(val)) {
         return {
@@ -531,14 +531,9 @@ export const FieldConfigs: FieldConfig<any>[] = [
   {
     profile_id: 39,
     label: 'Weitere Informationen',
-    key: 'isoMetadata.additionalInformation',
-    validator: (val: any) => {
-      if (!isDefined(val)) {
-        return {
-          valid: false,
-          helpText: 'Bitte geben Sie zusätzliche Informationen an.'
-        };
-      }
+    key: 'isoMetadata.contentDescriptions',
+    validator: () => {
+      // Optional
       return { valid: true };
     },
     section: 'additional',

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -35,6 +35,7 @@
   import F31_TechnicalDescription from './Field/31_TechnicalDescription.svelte';
   import F32_Lineage from './Field/32_Lineage.svelte';
   import F39_AdditionalInformation from './Field/39_AdditionalInformation.svelte';
+  import F38_InspireAnnexVersionField from './Field/38_InspireAnnexVersionField.svelte';
   import ServicesSection from './service/ServicesSection.svelte';
   import FormFooter from './FormFooter.svelte';
   import type { MetadataCollection } from '$lib/models/metadata';
@@ -160,6 +161,7 @@
           <F04_PrivacyField />
           <F24_TermsOfUseField />
           <F07_AnnexThemeField {metadata} />
+          <F38_InspireAnnexVersionField {metadata} />
           <F37_QualityReportCheckField {metadata} />
           <F06_HighValueDatasetField />
           <F13_TopicCategory {metadata} />

--- a/src/lib/components/Form/Inputs/SelectInput.svelte
+++ b/src/lib/components/Form/Inputs/SelectInput.svelte
@@ -13,6 +13,7 @@
     label?: string;
     options: Option[];
     validationResult?: ValidationResult;
+    disabled?: boolean;
   };
 
   let {
@@ -21,6 +22,7 @@
     key,
     label,
     options,
+    disabled = false,
     validationResult
   }: InputProps = $props();
 
@@ -36,6 +38,7 @@
   bind:this={element}
   class="select-input"
   {label}
+  {disabled}
   hiddenInput
   input$name={key}
   menu$anchorElement={document.body}

--- a/src/lib/components/Overview/Pagination.svelte
+++ b/src/lib/components/Overview/Pagination.svelte
@@ -13,10 +13,10 @@
 
   const currentUrl = $derived(page.url);
   const maxPage = $derived(pagingInfo.totalPages - 1);
-  const currentPage = $derived(pagingInfo.pageable.pageNumber + 1);
+  const currentPage = $derived(Number(currentUrl.searchParams.get('page') || 1));
   const hasPrevious = $derived(currentPage > 1);
   const hasNext = $derived(maxPage > currentPage);
-  const pageSize = $derived(pagingInfo.pageable.pageSize.toString() || '10');
+  const pageSize = $derived(currentUrl.searchParams.get('size')?.toString() || '10');
 
   const updatePage = (page: number) => {
     const newUrl = new URL(currentUrl);
@@ -26,19 +26,21 @@
     if (!currentUrl.searchParams.get('size')) {
       newUrl.searchParams.set('size', '10');
     }
-    goto(newUrl);
+    goto(newUrl, {
+      keepFocus: true,
+    });
   };
 
   const updatePageSize = (size: number) => {
     const newUrl = new URL(currentUrl);
     newUrl.searchParams.set('size', size.toString());
-    newUrl.searchParams.set('page', '0');
+    newUrl.searchParams.set('page', '1');
     goto(newUrl);
   };
 
   const onPageInputChange = (e: Event) => {
     const target = e.target as HTMLInputElement;
-    updatePage(Number(target.value) - 1);
+    updatePage(Number(target.value));
   };
 </script>
 

--- a/src/lib/models/metadata.ts
+++ b/src/lib/models/metadata.ts
@@ -168,8 +168,8 @@ export type Extent = {
 
 export type Lineage = {
   title: string;
-  source: string;
-  publishDate: string;
+  identifier: string;
+  date: string;
 };
 
 export type Keywords = {


### PR DESCRIPTION
This pull request includes several changes to the form fields in the metadata profile components. The changes focus on adding new fields, updating existing fields, and refining the validation and persistence logic.

### New Fields Added:
* Added a new field for "Schema-Version des INSPIRE Themas" in the `FieldConfigs` file.
* Introduced a new component for the "Inspire Annex Version" field.

### Updates to Existing Fields:
* Updated the `TechnicalDescription` field to use the correct key and simplified the data handling logic. [[1]](diffhunk://#diff-974cd68dcf69117b72e0458fa7854182bf5d9f87da15d52f4eac8414203bbb81L7-R9) [[2]](diffhunk://#diff-974cd68dcf69117b72e0458fa7854182bf5d9f87da15d52f4eac8414203bbb81L32-R31)
* Modified the `Lineage` field to use new attributes and updated the persistence logic accordingly. [[1]](diffhunk://#diff-99f41c4667cbd7685ef9f5500197de1f76e6dfe2b44f61707c350bf3a2b489a6L12-R36) [[2]](diffhunk://#diff-99f41c4667cbd7685ef9f5500197de1f76e6dfe2b44f61707c350bf3a2b489a6L37-R47) [[3]](diffhunk://#diff-99f41c4667cbd7685ef9f5500197de1f76e6dfe2b44f61707c350bf3a2b489a6L53-R63) [[4]](diffhunk://#diff-99f41c4667cbd7685ef9f5500197de1f76e6dfe2b44f61707c350bf3a2b489a6L80-R89) [[5]](diffhunk://#diff-99f41c4667cbd7685ef9f5500197de1f76e6dfe2b44f61707c350bf3a2b489a6L112-R128) [[6]](diffhunk://#diff-99f41c4667cbd7685ef9f5500197de1f76e6dfe2b44f61707c350bf3a2b489a6L136)
* Changed the `AdditionalInformation` field to use `ContentDescription` and added a confirmation dialog for deletions. [[1]](diffhunk://#diff-73695662e207bab7536674b95d6c29c2a4b9767e5259460ab7e50b6ce739da51R6-R122) [[2]](diffhunk://#diff-73695662e207bab7536674b95d6c29c2a4b9767e5259460ab7e50b6ce739da51L94-L97) [[3]](diffhunk://#diff-73695662e207bab7536674b95d6c29c2a4b9767e5259460ab7e50b6ce739da51L111-R147)

### Refinements and Bug Fixes:
* Corrected the validation logic in the `ContactsField` to handle empty values properly. [[1]](diffhunk://#diff-0d10315570be264fcc4a00dad64a469da0fda2bb884ddf2e24deb022d6cbeb46L18-R18) [[2]](diffhunk://#diff-0d10315570be264fcc4a00dad64a469da0fda2bb884ddf2e24deb022d6cbeb46R30-R39)
* Improved the `TermsOfUseField` to bind the value correctly.
* Removed the `AutoFillButton` and updated the auto-fill logic in the `TopicCategory` field. [[1]](diffhunk://#diff-b74a401a78533dd654d3199b3cd4b208d759573e4fbb84e4a1415659fe159229L6) [[2]](diffhunk://#diff-b74a401a78533dd654d3199b3cd4b208d759573e4fbb84e4a1415659fe159229R23-R26) [[3]](diffhunk://#diff-b74a401a78533dd654d3199b3cd4b208d759573e4fbb84e4a1415659fe159229L44-R51) [[4]](diffhunk://#diff-b74a401a78533dd654d3199b3cd4b208d759573e4fbb84e4a1415659fe159229R67-R74)
* Simplified the `ContentDescription` field to use a single text input instead of a list.

These changes enhance the functionality and usability of the form fields within the metadata profile components.

Relies on https://github.com/gdi-be/mde-backend/pull/38