### PR TITLE
Use mounted codelists

### DIFF
--- a/src/lib/components/Form/Field/04_PrivacyField.svelte
+++ b/src/lib/components/Form/Field/04_PrivacyField.svelte
@@ -4,30 +4,9 @@
   import FieldTools from '../FieldTools.svelte';
   import RadioInput from '../Inputs/RadioInput.svelte';
   import type { ValidationResult } from '../FieldsConfig';
+  import type { Option } from '$lib/models/form';
 
   const KEY = 'clientMetadata.privacy';
-  const OPTIONS: {
-    key: string;
-    label: string;
-  }[] = [
-    {
-      key: 'NONE',
-      label: 'Nicht Datenschutz relevant'
-    },
-    {
-      key: 'INTERNAL_USE_ONLY',
-      label:
-        'Schutz von Daten juristischer Personen und deren Interessen - Nutzungsbestimmung "Nur für den Dienstgebrauch"'
-    },
-    {
-      key: 'PERSONAL_DATA',
-      label: 'Schutz von persönlichen Daten bei natürlichen Personen'
-    },
-    {
-      key: 'CRITICAL_INFRASTRUCTURE',
-      label: 'Schutz von Daten, die als Kritische Infrastruktur eingestuft werden'
-    }
-  ];
 
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
@@ -44,18 +23,28 @@
       showCheckmark = true;
     }
   };
+
+  const fetchOptions = async () => {
+    const response = await fetch('/data/privacy');
+    const data: Option[] = await response.json();
+    return data;
+  };
 </script>
 
 <div class="data-protection-field">
   <Paper>
-    <RadioInput
-      key={KEY}
-      label={fieldConfig?.label}
-      options={OPTIONS}
-      {validationResult}
-      {value}
-      {onChange}
-    />
+    {#await fetchOptions()}
+      <p>Lade Datenschutz Optionen</p>
+    {:then OPTIONS}
+      <RadioInput
+        key={KEY}
+        label={fieldConfig?.label}
+        options={OPTIONS}
+        {validationResult}
+        {value}
+        {onChange}
+      />
+    {/await}
   </Paper>
   <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>

--- a/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
+++ b/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
@@ -5,38 +5,12 @@
   import Switch from '@smui/switch';
   import FormField from '@smui/form-field';
   import SelectInput from '../Inputs/SelectInput.svelte';
+  import type { Option } from '$lib/models/form';
 
   const CHECKED_KEY = 'clientMetadata.highValueDataset';
   const CATEGORY_KEY = 'isoMetadata.highValueDataCategory';
   const CHECK_LABEL = 'High Value Data Set';
   const LABEL = 'High Value Data Kategorie';
-
-  const OPTIONS = [
-    {
-      key: 'geospatial',
-      label: 'Geodaten (Geospatial)'
-    },
-    {
-      key: 'earth_observation_and_environment',
-      label: 'Erdbeobachtung und Umwelt (Earth Observation and Environment)'
-    },
-    {
-      key: 'meteorological',
-      label: 'Meteorologische Daten (Meteorological)'
-    },
-    {
-      key: 'statistics',
-      label: 'Statistische Daten (Statistics)'
-    },
-    {
-      key: 'companies_and_company_ownership',
-      label: 'Unternehmens- und Eigentümerdaten (Companies and Company Ownership)'
-    },
-    {
-      key: 'mobility',
-      label: 'Mobilitätsdaten (Mobility)'
-    }
-  ];
 
   const checkedValueFromData = $derived(getValue<boolean>(CHECKED_KEY));
   let checkedValue = $state(false);
@@ -65,6 +39,12 @@
       showCheckmark = true;
     }
   };
+
+  const fetchOptions = async () => {
+    const response = await fetch('/data/hvd_categories');
+    const data: Option[] = await response.json();
+    return data;
+  };
 </script>
 
 <div class="high-value-dataset-check-field">
@@ -76,13 +56,17 @@
       <Switch bind:checked={checkedValue} onSMUISwitchChange={onCheckChange} />
     </FormField>
     {#if checkedValue}
-      <SelectInput
-        key={CATEGORY_KEY}
-        label={LABEL}
-        options={OPTIONS}
-        value={selectionValue}
-        onChange={onSelectionChange}
-      />
+      {#await fetchOptions()}
+        <p>Lade HVD Kategorien</p>
+      {:then OPTIONS}
+        <SelectInput
+          key={CATEGORY_KEY}
+          label={LABEL}
+          options={OPTIONS}
+          value={selectionValue}
+          onChange={onSelectionChange}
+        />
+      {/await}
     {/if}
   </Paper>
   <FieldTools key={CATEGORY_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />

--- a/src/lib/components/Form/Field/07_AnnexThemeField.svelte
+++ b/src/lib/components/Form/Field/07_AnnexThemeField.svelte
@@ -3,7 +3,6 @@
   import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import SelectInput from '../Inputs/SelectInput.svelte';
-  import type { InspireRegister } from '$lib/models/inspire';
   import type { Option } from '$lib/models/form';
   import type { ValidationResult } from '../FieldsConfig';
 
@@ -33,19 +32,12 @@
 
   const fetchOptions = async () => {
     const response = await fetch('/data/inspire_themes');
-    const data: InspireRegister = await response.json();
+    const data: Option[] = await response.json();
 
-    if (!data.register) {
-      return [];
-    }
+    console.log(data);
 
-    return data.register.containeditems
-      .map((entry) => ({
-        key: entry.theme.id.split('/').at(-1)!.toUpperCase(),
-        label: entry.theme.label.text
-      }))
-      .filter((entry: Option) => entry.key !== 'AC-MF')
-      .sort((a: Option, b: Option) => a.label.localeCompare(b.label));
+    return data;
+
   };
 </script>
 

--- a/src/lib/components/Form/Field/07_AnnexThemeField.svelte
+++ b/src/lib/components/Form/Field/07_AnnexThemeField.svelte
@@ -33,11 +33,7 @@
   const fetchOptions = async () => {
     const response = await fetch('/data/inspire_themes');
     const data: Option[] = await response.json();
-
-    console.log(data);
-
     return data;
-
   };
 </script>
 

--- a/src/lib/components/Form/Field/18_ExtentField.svelte
+++ b/src/lib/components/Form/Field/18_ExtentField.svelte
@@ -8,6 +8,8 @@
   import { transformExtent } from '$lib/util';
   import type { ValidationResult, ValidationResultList } from '../FieldsConfig';
   import ValidationFeedbackText from '../ValidationFeedbackText.svelte';
+  import type { Option } from '$lib/models/form';
+  import { onMount } from 'svelte';
 
   const KEY = 'isoMetadata.extent';
   const CRS_KEY = 'isoMetadata.crs';
@@ -16,36 +18,6 @@
   const LABEL_MIN_X = 'Minimaler X-Wert';
   const LABEL_MAX_Y = 'Maximaler Y-Wert';
   const LABEL_MIN_Y = 'Minimaler Y-Wert';
-
-  const CRS_OPTIONS: {
-    key: string;
-    label: CRS;
-  }[] = [
-    {
-      key: 'http://www.opengis.net/def/crs/EPSG/0/25833',
-      label: 'EPSG:25833'
-    },
-    {
-      key: 'http://www.opengis.net/def/crs/EPSG/0/4326',
-      label: 'EPSG:4326'
-    },
-    {
-      key: 'http://www.opengis.net/def/crs/EPSG/0/3857',
-      label: 'EPSG:3857'
-    },
-    {
-      key: 'http://www.opengis.net/def/crs/EPSG/0/4258',
-      label: 'EPSG:4258'
-    },
-    {
-      key: 'http://www.opengis.net/def/crs/EPSG/0/25832',
-      label: 'EPSG:25832'
-    },
-    {
-      key: 'http://www.opengis.net/def/crs/EPSG/0/3035',
-      label: 'EPSG:3035'
-    }
-  ];
 
   let initialCRSKey = getValue<CRS>(CRS_KEY);
   const valueFromData = $derived(getValue<Extent>(KEY));
@@ -61,11 +33,12 @@
     }
   });
 
-  let crsKey = $state(initialCRSKey || CRS_OPTIONS[1].key);
-  let crs = $derived(CRS_OPTIONS.find((option) => option.key === crsKey) || CRS_OPTIONS[1]);
+  let crsOptions = $state<Option[]>([]);
+  let crsKey = $state(initialCRSKey);
+  let crs = $derived(crsOptions.find((option) => option.key === crsKey));
   let showCheckmark = $state(false);
   let transformedValue = $derived(
-    crs ? transformExtent(value4326, 'EPSG:4326', crs.label) : value4326
+    crs ? transformExtent(value4326, 'EPSG:4326', crs.label as CRS) : value4326
   );
   let isBerlin = $derived(
     value4326.minx === 13.079 &&
@@ -91,7 +64,7 @@
       ...transformedValue,
       [key]: newValue
     };
-    value4326 = transformExtent(newTransformedValue, crs.label, 'EPSG:4326');
+    value4326 = transformExtent(newTransformedValue, crs?.label as CRS, 'EPSG:4326');
   };
 
   const sendValue = async () => {
@@ -105,13 +78,22 @@
     if (!Array.isArray(validationResult)) return;
     return validationResult.find(({ subKey }) => subKey === k);
   };
+
+  onMount(async () => {
+    const response = await fetch('/data/crs');
+    crsOptions = await response.json();
+
+    if (!crsKey && crsOptions[0].key) {
+      crsKey = crsOptions[0].key as CRS;
+    }
+  });
 </script>
 
 <div class="extent-field">
   <fieldset>
     <legend>{fieldConfig?.label}</legend>
     <div class="tools">
-      <SelectInput bind:value={crsKey} key={KEY} label={CRS_LABEL} options={CRS_OPTIONS} />
+      <SelectInput bind:value={crsKey} key={KEY} label={CRS_LABEL} options={crsOptions} />
       <Button
         type="button"
         variant={isBerlin ? 'raised' : 'text'}
@@ -157,7 +139,7 @@
             const target = evt?.target as HTMLInputElement;
             onChange(Number(target.value), 'minx');
           }}
-          input$step={['EPSG:4326', 'EPSG:4258'].includes(crs.label) ? '0.0001' : undefined}
+          input$step={['EPSG:4326', 'EPSG:4258'].includes(crs?.label as CRS) ? '0.0001' : undefined}
           validationResult={getFieldValidation('minx')}
         />
         <NumberInput
@@ -168,7 +150,7 @@
             const target = evt?.target as HTMLInputElement;
             onChange(Number(target.value), 'maxx');
           }}
-          input$step={['EPSG:4326', 'EPSG:4258'].includes(crs.label) ? '0.0001' : undefined}
+          input$step={['EPSG:4326', 'EPSG:4258'].includes(crs?.label as CRS) ? '0.0001' : undefined}
           validationResult={getFieldValidation('maxx')}
         />
       </div>
@@ -181,7 +163,7 @@
             const target = evt?.target as HTMLInputElement;
             onChange(Number(target.value), 'miny');
           }}
-          input$step={['EPSG:4326', 'EPSG:4258'].includes(crs.label) ? '0.0001' : undefined}
+          input$step={['EPSG:4326', 'EPSG:4258'].includes(crs?.label as CRS) ? '0.0001' : undefined}
           validationResult={getFieldValidation('miny')}
         />
         <NumberInput
@@ -192,7 +174,7 @@
             const target = evt?.target as HTMLInputElement;
             onChange(Number(target.value), 'maxy');
           }}
-          input$step={['EPSG:4326', 'EPSG:4258'].includes(crs.label) ? '0.0001' : undefined}
+          input$step={['EPSG:4326', 'EPSG:4258'].includes(crs?.label as CRS) ? '0.0001' : undefined}
           validationResult={getFieldValidation('maxy')}
         />
       </div>

--- a/src/lib/models/metadata.ts
+++ b/src/lib/models/metadata.ts
@@ -33,13 +33,7 @@ export type Comment = {
   userName: string;
 };
 
-export type CRS =
-  | 'EPSG:4326'
-  | 'EPSG:3857'
-  | 'EPSG:25833'
-  | 'EPSG:25832'
-  | 'EPSG:4258'
-  | 'EPSG:3035';
+export type CRS = `EPSG:${number}`;
 
 export type ServiceType = 'WFS' | 'WMS' | 'ATOM' | 'WMTS';
 

--- a/src/routes/data/crs/+server.ts
+++ b/src/routes/data/crs/+server.ts
@@ -1,0 +1,15 @@
+import { error, json } from '@sveltejs/kit';
+import { getAccessToken } from '$lib/auth/cookies.js';
+import { parse } from 'yaml';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ cookies }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+
+  const file = Bun.file('/data/codelists/crs.yaml');
+  const themes = await file.text();
+  const parsed = parse(themes);
+
+  return json(parsed);
+}

--- a/src/routes/data/extents/+server.ts
+++ b/src/routes/data/extents/+server.ts
@@ -1,0 +1,15 @@
+import { error, json } from '@sveltejs/kit';
+import { getAccessToken } from '$lib/auth/cookies.js';
+import { parse } from 'yaml';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ cookies }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+
+  const file = Bun.file('/data/codelists/extents.yaml');
+  const themes = await file.text();
+  const parsed = parse(themes);
+
+  return json(parsed);
+}

--- a/src/routes/data/hvd_categories/+server.ts
+++ b/src/routes/data/hvd_categories/+server.ts
@@ -1,0 +1,15 @@
+import { error, json } from '@sveltejs/kit';
+import { getAccessToken } from '$lib/auth/cookies.js';
+import { parse } from 'yaml';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ cookies }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+
+  const file = Bun.file('/data/codelists/hvd_categories.yaml');
+  const themes = await file.text();
+  const parsed = parse(themes);
+
+  return json(parsed);
+}

--- a/src/routes/data/inspire_themes/+server.ts
+++ b/src/routes/data/inspire_themes/+server.ts
@@ -1,22 +1,15 @@
 import { error, json } from '@sveltejs/kit';
 import { getAccessToken } from '$lib/auth/cookies.js';
+import { parse } from 'yaml';
 
 /** @type {import('./$types').RequestHandler} */
-export async function GET({ cookies, fetch }) {
-  // TODO: add caching/fallback? Maybe via hooks?
-
+export async function GET({ cookies }) {
   const token = await getAccessToken(cookies);
   if (!token) return error(401, 'Unauthorized');
 
-  const response = await fetch('https://inspire.ec.europa.eu/theme/theme.de.json', {
-    method: 'GET',
-    headers: {
-      'content-type': 'application/json',
-      'Access-Control-Allow-Origin': '*'
-    }
-  });
+  const file = Bun.file('/data/codelists/inspire_themes.yaml');
+  const themes = await file.text();
+  const parsed = parse(themes);
 
-  const keywords = await response.json();
-
-  return json(keywords);
+  return json(parsed);
 }

--- a/src/routes/data/privacy/+server.ts
+++ b/src/routes/data/privacy/+server.ts
@@ -1,0 +1,15 @@
+import { error, json } from '@sveltejs/kit';
+import { getAccessToken } from '$lib/auth/cookies.js';
+import { parse } from 'yaml';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ cookies }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+
+  const file = Bun.file('/data/codelists/privacy.yaml');
+  const themes = await file.text();
+  const parsed = parse(themes);
+
+  return json(parsed);
+}


### PR DESCRIPTION
This pull request includes significant changes to the form fields and the data fetching mechanism for various options in the application. The primary changes involve replacing hardcoded options with dynamic fetching from server endpoints, which enhances the flexibility and maintainability of the code.

### Dynamic Data Fetching for Form Fields:

* [`src/lib/components/Form/Field/04_PrivacyField.svelte`](diffhunk://#diff-40156b48051263d717f07197989dcb45e8dde9ae6278a88e5fe9529b45d4d65bR7-L30): Removed hardcoded privacy options and added a function to fetch options from the `/data/privacy` endpoint. [[1]](diffhunk://#diff-40156b48051263d717f07197989dcb45e8dde9ae6278a88e5fe9529b45d4d65bR7-L30) [[2]](diffhunk://#diff-40156b48051263d717f07197989dcb45e8dde9ae6278a88e5fe9529b45d4d65bR26-R38) [[3]](diffhunk://#diff-40156b48051263d717f07197989dcb45e8dde9ae6278a88e5fe9529b45d4d65bR47)
* [`src/lib/components/Form/Field/06_HighValueDatasetField.svelte`](diffhunk://#diff-30a5621f533f3030b9b56f66fb7e4381c93f204b99471430b2853ead86e1bdceR8-L40): Removed hardcoded high-value dataset categories and added a function to fetch options from the `/data/hvd_categories` endpoint. [[1]](diffhunk://#diff-30a5621f533f3030b9b56f66fb7e4381c93f204b99471430b2853ead86e1bdceR8-L40) [[2]](diffhunk://#diff-30a5621f533f3030b9b56f66fb7e4381c93f204b99471430b2853ead86e1bdceR42-R47) [[3]](diffhunk://#diff-30a5621f533f3030b9b56f66fb7e4381c93f204b99471430b2853ead86e1bdceR59-R69)
* [`src/lib/components/Form/Field/07_AnnexThemeField.svelte`](diffhunk://#diff-6b44375a2b894f0ce5af0c76d2c4a38428075558e7467670463fbd698bfdaf66L6): Simplified the fetching of inspire themes by directly returning the parsed data from the `/data/inspire_themes` endpoint. [[1]](diffhunk://#diff-6b44375a2b894f0ce5af0c76d2c4a38428075558e7467670463fbd698bfdaf66L6) [[2]](diffhunk://#diff-6b44375a2b894f0ce5af0c76d2c4a38428075558e7467670463fbd698bfdaf66L36-R36)
* [`src/lib/components/Form/Field/17_CoordinateSystemField.svelte`](diffhunk://#diff-226ec9fcd63dabfd72b22934798f8c480438ec3bce83cf6ccd25983ac09129f9R7-L36): Removed hardcoded coordinate system options and added a function to fetch options from the `/data/crs` endpoint. [[1]](diffhunk://#diff-226ec9fcd63dabfd72b22934798f8c480438ec3bce83cf6ccd25983ac09129f9R7-L36) [[2]](diffhunk://#diff-226ec9fcd63dabfd72b22934798f8c480438ec3bce83cf6ccd25983ac09129f9L47-R39) [[3]](diffhunk://#diff-226ec9fcd63dabfd72b22934798f8c480438ec3bce83cf6ccd25983ac09129f9R48)
* [`src/lib/components/Form/Field/18_ExtentField.svelte`](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bR11-R17): Added dynamic fetching for extent and CRS options and updated the component to use these fetched options. [[1]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bR11-R17) [[2]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bL20-L49) [[3]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bL64-R57) [[4]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bL94-R71) [[5]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bR85-R118) [[6]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bL160-R130) [[7]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bL171-R141) [[8]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bL184-R154) [[9]](diffhunk://#diff-5f9a5d1ed11ed4552b2a82847fe30c3f11fa96add789de32aa7a9795db7ad92bL195-R165)

### Server Endpoints for Data Fetching:

* [`src/routes/data/crs/+server.ts`](diffhunk://#diff-2d94ac074c422c3d62b1ad660435ca5178e725d36899f5853e96218baf916855R1-R15): Added a new endpoint to fetch coordinate system options from a YAML file.
* [`src/routes/data/extents/+server.ts`](diffhunk://#diff-1555b32c83da9041551982cf347bb69607c312decc48331142cbd78035f488dfR1-R15): Added a new endpoint to fetch extent options from a YAML file.
* [`src/routes/data/hvd_categories/+server.ts`](diffhunk://#diff-990247b99ba40a344874b0a933f8c36e2ca788595bb71967e5b331e28bd5630fR1-R15): Added a new endpoint to fetch high-value dataset categories from a YAML file.
* [`src/routes/data/inspire_themes/+server.ts`](diffhunk://#diff-5986885a6358a4732d49569d5e8589e10997584a90b5d269af8012d05e10289eR3-R14): Modified the endpoint to fetch inspire themes from a YAML file instead of an external API.
* [`src/routes/data/privacy/+server.ts`](diffhunk://#diff-098bd594d42df5efaa9262bda34508720357ef5e02c60fbcc9fc2dc72eef8604R1-R15): Added a new endpoint to fetch privacy options from a YAML file.

### Type Definitions:

* [`src/lib/models/metadata.ts`](diffhunk://#diff-1c713e730e92157b330329f86dd28db9f8ed2f20be22ec3c8f684c11b65ad823L36-R36): Changed the `CRS` type definition to a more flexible format.

:warning: This requires the codelists to be mounted into the client container at `/data/codelists`. compare: https://github.com/gdi-be/mde-deployment/pull/13