### PR TITLE
Replace image source with variables

### DIFF
--- a/src/routes/replace_variable/+server.ts
+++ b/src/routes/replace_variable/+server.ts
@@ -1,0 +1,19 @@
+import { error } from '@sveltejs/kit';
+import { getAccessToken } from '$lib/auth/cookies.js';
+
+const file = Bun.file('/data/variables.json');
+const variables = await file.json();
+
+/** @type {import('./$types').RequestHandler} */
+export async function POST({ cookies, request }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+
+  let { value } = await request.json();
+
+  Object.keys(variables).forEach((key) => {
+    value = value.replace(key, variables[key]);
+  });
+
+  return new Response(value, { status: 200});
+}


### PR DESCRIPTION
This pull request introduces improvements to the handling of image previews in the `MetadataCard` component and adds a new server endpoint for variable replacement. The most important changes include adding an asynchronous function to fetch and replace image sources, and implementing a server-side endpoint to handle variable replacements securely.

Improvements to image preview handling:

* [`src/lib/components/Overview/MetadataCard.svelte`](diffhunk://#diff-078690102e131afb5c75632c9bee23d25c4884ebdace63d4d21f2a43195b7db9R136-R187): Added an `async` function `getImageSource` to fetch and replace image sources, and updated the image rendering logic to use the result of this function. This ensures that the correct image source is used or falls back to a default image if the fetch fails.

Server-side variable replacement:

* [`src/routes/replace_variable/+server.ts`](diffhunk://#diff-c69c464016400cc6b7ff80259b55d74a4d8c03fdab702bd2b54887b718678b6aR1-R19): Added a new POST endpoint that replaces variables in a given value based on a JSON file. This endpoint checks for an access token to ensure that only authorized requests can perform the replacement.

:warning: requires mounted variables file at /data/variables.json