### PR TITLE
Adds download button

### DIFF
--- a/src/lib/api/metadata.ts
+++ b/src/lib/api/metadata.ts
@@ -447,7 +447,6 @@ export const getTeam = async ({
     headers
   });
 
-
   if (!response.ok) {
     throw new Error(`HTTP error status: ${response.status}`);
   }

--- a/src/lib/components/Form/FormFooter.svelte
+++ b/src/lib/components/Form/FormFooter.svelte
@@ -88,12 +88,22 @@
     });
 
     if (response.ok) {
+      let label = `${metadata?.isoMetadata.title || metadata}`;
+      label = label
+        .replace(/ä/g, 'ae')
+        .replace(/ö/g, 'oe')
+        .replace(/ü/g, 'ue')
+        .replace(/ß/g, 'ss')
+        .replace(/\s+/g, '_');
+      const date = new Date().toISOString().split('T')[0];
+      const fileName = `${label}_${date}`;
+
       // response is a zip file blob that will be downloaded
       const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${metadataId}.zip`;
+      a.download = `${fileName}.zip`;
       document.body.appendChild(a);
       a.click();
       a.remove();

--- a/src/lib/components/Form/FormFooter.svelte
+++ b/src/lib/components/Form/FormFooter.svelte
@@ -9,6 +9,7 @@
   import { getContext, type Snippet } from 'svelte';
   import ValidationPanel from './ValidationPanel.svelte';
   import AssignmentDialog from './AssignmentDialog.svelte';
+  import { page } from '$app/state';
 
   type FormFooterProps = {
     metadata?: MetadataCollection;
@@ -79,6 +80,27 @@
     assignmentPanelVisible = false;
   };
 
+  const onDownloadClick = async () => {
+    const metadataId = metadata?.metadataId;
+    const url = `${page.url.origin}/metadata/${metadataId}/download`;
+    const response = await fetch(url, {
+      method: 'GET'
+    });
+
+    if (response.ok) {
+      // response is a zip file blob that will be downloaded
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${metadataId}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    }
+  };
+
 </script>
 
 <footer class="form-footer">
@@ -131,6 +153,15 @@
         <Icon class="material-icons">rocket_launch</Icon>
       </Button>
     {/if}
+    <Button
+      class="submit-button"
+      title="Download"
+      variant="raised"
+      onclick={onDownloadClick}
+    >
+      <Label>Download</Label>
+      <Icon class="material-icons">download</Icon>
+    </Button>
   </div>
 </footer>
 

--- a/src/lib/components/Overview/MetadataCard.svelte
+++ b/src/lib/components/Overview/MetadataCard.svelte
@@ -133,7 +133,7 @@
       }
     );
   }
-  // previewNotAvailable ? FALLBACK_IMAGE : (metadata.isoMetadata.preview as string)
+
   async function getImageSource() {
     if (metadata.isoMetadata?.preview) {
       const response = await fetch('/replace_variable', {

--- a/src/routes/metadata/[metadataid]/download/+server.ts
+++ b/src/routes/metadata/[metadataid]/download/+server.ts
@@ -1,0 +1,23 @@
+import { error } from '@sveltejs/kit';
+import { getAccessToken } from '$lib/auth/cookies.js';
+import { env } from '$env/dynamic/private';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ cookies, params }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+
+  if (!params.metadataid) {
+    return error(400, 'Bad Request');
+  }
+
+  const response = await fetch(`${env.BACKEND_URL}/metadata/${params.metadataid}/download`);
+
+  if (!response.ok) {
+    return error(response.status, response.statusText);
+  }
+
+  const blob = await response.blob();
+  return new Response(blob);
+
+}


### PR DESCRIPTION
This adds a download button to the FormFooter:

Enhancements:

* [`src/lib/components/Form/FormFooter.svelte`](diffhunk://#diff-fd8f5245b206bca00d08427344d8f22fa8c153f2db68fedca6a559b00d9159b2R83-R103): Added a new download button that triggers the `onDownloadClick` function to download metadata as a zip file. [[1]](diffhunk://#diff-fd8f5245b206bca00d08427344d8f22fa8c153f2db68fedca6a559b00d9159b2R83-R103) [[2]](diffhunk://#diff-fd8f5245b206bca00d08427344d8f22fa8c153f2db68fedca6a559b00d9159b2R156-R164)
* `src/routes/metadata/[metadataid]/download/+server.ts`: Implemented a new server route to handle metadata download requests, ensuring proper authorization and error handling. ([src/routes/metadata/[metadataid]/download/+server.tsR1-R23](diffhunk://#diff-32c4b74033b9093f1e18978c761f9c1789af8502cc9dda83cb5bdfce296e7e8bR1-R23))

Minor code cleanups:

* [`src/lib/api/metadata.ts`](diffhunk://#diff-1615c38efabcd9dc25ece63c6a5445c4f57fdba48ea0a6e3d8e59857d30d857dL450): Removed an unnecessary blank line for cleaner code.
* [`src/lib/components/Overview/MetadataCard.svelte`](diffhunk://#diff-078690102e131afb5c75632c9bee23d25c4884ebdace63d4d21f2a43195b7db9L136-R136): Removed a commented-out line of code.