### PR TITLE
Rename roles

### DIFF
--- a/src/lib/components/AssignmentDialog.svelte
+++ b/src/lib/components/AssignmentDialog.svelte
@@ -19,26 +19,26 @@
 
   const canAssignToDataOwner = $derived(
     // Admin can do anything
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
       // Editors are responsible and I'm an Editor
-      (responsibleRole === 'Editor' && highestRole === 'Editor')
+      (responsibleRole === 'MdeEditor' && highestRole === 'MdeEditor')
   );
 
   const canAssignToEditor = $derived(
     // Admin can do anything
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
       // Its assigned to me and I'm not an Editor already
-      (assignedToMe && responsibleRole !== 'Editor')
+      (assignedToMe && responsibleRole !== 'MdeEditor')
   );
 
   const canAssignToQualityAssurance = $derived(
     // Admin can do anything
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
       // Editors are responsible and I'm an Editor
-      (responsibleRole === 'Editor' && highestRole === 'Editor')
+      (responsibleRole === 'MdeEditor' && highestRole === 'MdeEditor')
   );
 
-  const canApproveMetadata = $derived(['Administrator', 'QualityAssurance'].includes(highestRole));
+  const canApproveMetadata = $derived(['MdeAdministrator', 'MdeQualityAssurance'].includes(highestRole));
 
   const assignToRole = async (role: Role) => {
     if (!metadata) return;
@@ -148,7 +148,7 @@
           </Button>
         {/each}
       {/if}
-      <Button variant="outlined" onclick={() => assignToRole('Editor')}>
+      <Button variant="outlined" onclick={() => assignToRole('MdeEditor')}>
         <Label>An Redaktion übergeben</Label>
       </Button>
     </div>
@@ -184,7 +184,7 @@
           </Button>
         {/each}
       {/if}
-      <Button variant="outlined" onclick={() => assignToRole('QualityAssurance')}>
+      <Button variant="outlined" onclick={() => assignToRole('MdeQualityAssurance')}>
         <Label>An Qualitätssicherung übergeben</Label>
       </Button>
     </div>
@@ -208,13 +208,13 @@
           <p>Lade Team</p>
         {:then groups}
           {#if canAssignToEditor}
-            {@render assignToEditor(groups['Editor'])}
+            {@render assignToEditor(groups['MdeEditor'])}
           {/if}
           {#if canAssignToDataOwner}
-            {@render assignToDataOwner(groups['DataOwner'])}
+            {@render assignToDataOwner(groups['MdeDataOwner'])}
           {/if}
           {#if canAssignToQualityAssurance}
-            {@render assignToQualityAssurance(groups['QualityAssurance'])}
+            {@render assignToQualityAssurance(groups['MdeQualityAssurance'])}
           {/if}
         {:catch}
           {#if canAssignToEditor}

--- a/src/lib/components/Form/Field/38_InspireAnnexVersionField.svelte
+++ b/src/lib/components/Form/Field/38_InspireAnnexVersionField.svelte
@@ -35,7 +35,7 @@
   };
 </script>
 
-{#if metadataProfile === 'INSPIRE_HARMONISED' && highestRole !== 'DataOwner'}
+{#if metadataProfile === 'INSPIRE_HARMONISED' && highestRole !== 'MdeDataOwner'}
   <div class="inspire-annex-version-field">
     <TextInput
       bind:value

--- a/src/lib/components/Form/FormFooter.svelte
+++ b/src/lib/components/Form/FormFooter.svelte
@@ -40,22 +40,22 @@
   );
 
   let showPublishButton = $derived(
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
     (
       assignedToMe &&
-      allFieldsValid(metadata) && highestRole === 'Editor' &&
+      allFieldsValid(metadata) && highestRole === 'MdeEditor' &&
       metadata?.isoMetadata.valid === true
     )
   );
   let showValidateButton = $derived(
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
     (
-      allFieldsValid(metadata) && highestRole === 'Editor' &&
+      allFieldsValid(metadata) && highestRole === 'MdeEditor' &&
       metadata?.isoMetadata.valid === true
     )
   );
   let showAssignmentButton = $derived(
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
     assignedToMe ||
     highestRole === metadata?.responsibleRole
   );

--- a/src/lib/components/Overview/MetadataCard.svelte
+++ b/src/lib/components/Overview/MetadataCard.svelte
@@ -25,22 +25,22 @@
   const isTeamMember = $derived(metadata.teamMemberIds?.includes(userId));
   let previewNotAvailable = $state(!metadata.isoMetadata?.preview);
   const showDeleteAction = $derived(
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
     metadata.assignedUserId === userId &&
-    highestRole === 'Editor'
+    highestRole === 'MdeEditor'
   );
   const showCommentsAction = $derived(true);
   const showPrintAction = $derived(true);
   const showEditAction = $derived(
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
     metadata.assignedUserId === userId
   );
   const showAssignAction = $derived(
-    highestRole === 'Administrator' ||
+    highestRole === 'MdeAdministrator' ||
     (
       !assignedToSomeoneElse &&
       highestRole === metadata.responsibleRole &&
-      highestRole !== 'DataOwner'
+      highestRole !== 'MdeDataOwner'
     )
   );
 
@@ -62,7 +62,7 @@
   });
 
   const assignButtonLabeL = $derived.by(() => {
-    if (highestRole === 'Administrator') {
+    if (highestRole === 'MdeAdministrator') {
       return 'Zuweisung verwalten.';
     } else if (assignedToMe) {
       return 'Mir zugewiesen.\nKlicken um Zuordnung zu entfernen.';
@@ -72,7 +72,7 @@
   });
 
   const onAssign = () => {
-    if (highestRole === 'Administrator') {
+    if (highestRole === 'MdeAdministrator') {
       goto(`/metadata/${metadata.metadataId}/readonly?action=print`);
     } else if (assignedToMe) {
       removeAssignment();
@@ -264,11 +264,11 @@
         aria-label={assignButtonLabeL}
         title={assignButtonLabeL}
         onclick={onAssign}
-        pressed={assignedToMe && highestRole !== 'Administrator'}
+        pressed={assignedToMe && highestRole !== 'MdeAdministrator'}
       >
         <Icon class="material-icons-filled assigned-to-me" on>person_remove</Icon>
         <Icon class="material-icons-filled">
-          {highestRole === 'Administrator' ? 'manage_accounts' : 'person_check'}
+          {highestRole === 'MdeAdministrator' ? 'manage_accounts' : 'person_check'}
         </Icon>
       </IconButton>
     {/if}

--- a/src/lib/context/StatusesContest.svelte.ts
+++ b/src/lib/context/StatusesContest.svelte.ts
@@ -20,13 +20,13 @@ const defaultState = {
     key: 'READY_FOR_RELEASE',
     label: 'Geprüft'
   }, {
-    key: 'ROLE_DataOwner',
+    key: 'ROLE_MdeDataOwner',
     label: 'Datenhaltende Stelle'
   }, {
-    key: 'ROLE_Editor',
+    key: 'ROLE_MdeEditor',
     label: 'Redakteur'
   },{
-    key: 'ROLE_QualityAssurance',
+    key: 'ROLE_MdeQualityAssurance',
     label: 'Qualitätssicherung'
   }]
 };
@@ -44,14 +44,14 @@ export function getStatusesState() {
 export function getAvailableStatuses(token: Token) {
   const highestRole = getHighestRole(token);
   return statutesState.state.statuses.filter(status => {
-    if (highestRole === 'Administrator') {
+    if (highestRole === 'MdeAdministrator') {
       return true;
-    } else if (highestRole === 'Editor') {
-      return !['ROLE_QualityAssurance', 'ROLE_DataOwner'].includes(status.key);
-    } else if (highestRole === 'QualityAssurance') {
-      return !['ROLE_Editor', 'ROLE_DataOwner'].includes(status.key);
-    } else if (highestRole === 'DataOwner') {
-      return !['ROLE_Editor', 'ROLE_QualityAssurance', 'READY_FOR_RELEASE'].includes(status.key);
+    } else if (highestRole === 'MdeEditor') {
+      return !['ROLE_MdeQualityAssurance', 'ROLE_MdeDataOwner'].includes(status.key);
+    } else if (highestRole === 'MdeQualityAssurance') {
+      return !['ROLE_MdeEditor', 'ROLE_MdeDataOwner'].includes(status.key);
+    } else if (highestRole === 'MdeDataOwner') {
+      return !['ROLE_MdeEditor', 'ROLE_MdeQualityAssurance', 'READY_FOR_RELEASE'].includes(status.key);
     }
   });
 }

--- a/src/lib/models/keycloak.ts
+++ b/src/lib/models/keycloak.ts
@@ -28,4 +28,4 @@ export type Token = {
   email: string;
 };
 
-export type Role = 'DataOwner' | 'Editor' | 'QualityAssurance' | 'Administrator';
+export type Role = 'MdeDataOwner' | 'MdeEditor' | 'MdeQualityAssurance' | 'MdeAdministrator';

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -205,18 +205,18 @@ export function getLastUpdateValue(published: string, maintenanceFrequency: Main
 
 export const getRoleName = (role: Role): string => {
   const roleMapLong: Record<Role, string> = {
-    DataOwner: 'Datenhaltende Stelle',
-    Editor: 'Redakteur',
-    QualityAssurance: 'Qualitätsmanagment',
-    Administrator: 'Administrator'
+    MdeDataOwner: 'Datenhaltende Stelle',
+    MdeEditor: 'Redakteur',
+    MdeQualityAssurance: 'Qualitätsmanagment',
+    MdeAdministrator: 'Administrator'
   };
   return roleMapLong[role];
 };
 
 export const getHighestRole = (token: Token): Role => {
-  if (token.realm_access.roles.includes('Administrator')) return 'Administrator';
-  if (token.realm_access.roles.includes('Editor')) return 'Editor';
-  if (token.realm_access.roles.includes('QualityAssurance')) return 'QualityAssurance';
-  if (token.realm_access.roles.includes('DataOwner')) return 'DataOwner';
+  if (token.realm_access.roles.includes('MdeAdministrator')) return 'MdeAdministrator';
+  if (token.realm_access.roles.includes('MdeEditor')) return 'MdeEditor';
+  if (token.realm_access.roles.includes('MdeQualityAssurance')) return 'MdeQualityAssurance';
+  if (token.realm_access.roles.includes('MdeDataOwner')) return 'MdeDataOwner';
   throw Error('User has no role');
 };

--- a/src/routes/metadata/[metadataid]/+page.server.ts
+++ b/src/routes/metadata/[metadataid]/+page.server.ts
@@ -10,7 +10,7 @@ export async function load({ params, cookies, url }) {
   if (!token) return redirect(302, '/login');
 
   const parsedToken = parseToken(token);
-  const readOnly = getHighestRole(parsedToken) === 'QualityAssurance';
+  const readOnly = getHighestRole(parsedToken) === 'MdeQualityAssurance';
 
   if (readOnly) {
     return redirect(302, url + '/readonly');


### PR DESCRIPTION
This renames the roles to include a `Mde` prefix each. NOTE! You'll need to rename them in keycloak/AD as well, so that they're called `MdeAdministrator`, `MdeEditor` and so forth.