### PR TITLE
Remove vite proxy, include app internal route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,22 @@
 # [3.3.0](https://github.com/gdi-be/mde-client/compare/v3.2.0...v3.3.0) (2025-04-16)
 
-
 ### Bug Fixes
 
-* fix link in MetadataCard ([3a996e6](https://github.com/gdi-be/mde-client/commit/3a996e6df3257a845279bbe850618e9c91b85cb3))
-* fix rolename handling ([2625367](https://github.com/gdi-be/mde-client/commit/262536707d3643062a94770f21b4930cd7f16fe9))
-* linting ([a8b728a](https://github.com/gdi-be/mde-client/commit/a8b728ae195394299a42c02e39419f0465941c43))
-* linting ([a3bbd55](https://github.com/gdi-be/mde-client/commit/a3bbd5523fdf8d2281d2af9ad6d84e64f2dc974f))
-* typo ([4868355](https://github.com/gdi-be/mde-client/commit/48683559ac1434590a120fb3668f0ffaa847916b))
-* updates metadata context correctly ([41b8d87](https://github.com/gdi-be/mde-client/commit/41b8d87173a8e31765f8068ed137297693258aee))
-
+- fix link in MetadataCard ([3a996e6](https://github.com/gdi-be/mde-client/commit/3a996e6df3257a845279bbe850618e9c91b85cb3))
+- fix rolename handling ([2625367](https://github.com/gdi-be/mde-client/commit/262536707d3643062a94770f21b4930cd7f16fe9))
+- linting ([a8b728a](https://github.com/gdi-be/mde-client/commit/a8b728ae195394299a42c02e39419f0465941c43))
+- linting ([a3bbd55](https://github.com/gdi-be/mde-client/commit/a3bbd5523fdf8d2281d2af9ad6d84e64f2dc974f))
+- typo ([4868355](https://github.com/gdi-be/mde-client/commit/48683559ac1434590a120fb3668f0ffaa847916b))
+- updates metadata context correctly ([41b8d87](https://github.com/gdi-be/mde-client/commit/41b8d87173a8e31765f8068ed137297693258aee))
 
 ### Features
 
-* adds LayersForm ([0aed492](https://github.com/gdi-be/mde-client/commit/0aed4925b0b9520f094f3d97eeb64b1c8dc7b8cc))
-* introduces FeatureTypes ([ed96a40](https://github.com/gdi-be/mde-client/commit/ed96a40816aa27a21b529f54035a289e42f64c0a))
-* rename roles ([054ecc6](https://github.com/gdi-be/mde-client/commit/054ecc62a0b576543b4c99ba50623d6d57bba186))
-* show validation results ([44f8d28](https://github.com/gdi-be/mde-client/commit/44f8d28f8584c25f087d86ffda236d76cc8e2d81))
-* update legend size in the form ([551d4ec](https://github.com/gdi-be/mde-client/commit/551d4ecb331c35d8c24e9cf56427cb5abe003ac5))
-* updates readonly view ([0e9ffed](https://github.com/gdi-be/mde-client/commit/0e9ffede529a016ecc2d64d074b5b49dec4a6aab))
+- adds LayersForm ([0aed492](https://github.com/gdi-be/mde-client/commit/0aed4925b0b9520f094f3d97eeb64b1c8dc7b8cc))
+- introduces FeatureTypes ([ed96a40](https://github.com/gdi-be/mde-client/commit/ed96a40816aa27a21b529f54035a289e42f64c0a))
+- rename roles ([054ecc6](https://github.com/gdi-be/mde-client/commit/054ecc62a0b576543b4c99ba50623d6d57bba186))
+- show validation results ([44f8d28](https://github.com/gdi-be/mde-client/commit/44f8d28f8584c25f087d86ffda236d76cc8e2d81))
+- update legend size in the form ([551d4ec](https://github.com/gdi-be/mde-client/commit/551d4ecb331c35d8c24e9cf56427cb5abe003ac5))
+- updates readonly view ([0e9ffed](https://github.com/gdi-be/mde-client/commit/0e9ffede529a016ecc2d64d074b5b49dec4a6aab))
 
 # [3.2.0](https://github.com/gdi-be/mde-client/compare/v3.1.0...v3.2.0) (2025-04-10)
 

--- a/src/routes/events/subscribe/+server.ts
+++ b/src/routes/events/subscribe/+server.ts
@@ -1,0 +1,30 @@
+import { error } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { getAccessToken } from '$lib/auth/cookies.js';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ cookies }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+
+  const headers = new Headers({
+    Authorization: `Bearer ${token}`
+  });
+
+  const response = await fetch(`${env.BACKEND_URL}/events/subscribe`, {
+    method: 'GET',
+    headers
+  });
+
+  if (!response.ok) {
+    throw error(response.status, 'Failed to proxy events subscription');
+  }
+
+  return new Response(response.body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive'
+    }
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,88 +1,5 @@
 import { defineConfig } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
-import type { ClientRequest, IncomingMessage } from 'http';
-
-const onProxyReq = async (proxyReq: ClientRequest) => {
-  const cookie = proxyReq.getHeader('cookie');
-
-  if (!cookie || typeof cookie !== 'string') {
-    return;
-  }
-
-  const cookies = cookie.split(';').map((c) => c.trim());
-  const accessTokenCookie = cookies.find((c) => c.startsWith('access_token='));
-  const refreshTokenCookie = cookies.find((c) => c.startsWith('refresh_token='));
-
-  if (!accessTokenCookie && !refreshTokenCookie) {
-    console.error('No access token or refresh token found in cookies');
-    return;
-  }
-
-  if (accessTokenCookie) {
-    const accessToken = accessTokenCookie.split('=')[1];
-
-    proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
-
-    return;
-  }
-
-  if (refreshTokenCookie) {
-    const refreshToken = refreshTokenCookie?.split('=')[1];
-
-    const url = process.env.AUTH_KEYCLOAK_URL;
-    if (!url) {
-      return;
-    }
-
-    const realm = process.env.AUTH_KEYCLOAK_REALM;
-    if (!realm) {
-      return;
-    }
-
-    const clientId = process.env.AUTH_KEYCLOAK_CLIENT_ID;
-    if (!clientId) {
-      return;
-    }
-
-    const clientSecret = process.env.AUTH_KEYCLOAK_CLIENT_SECRET;
-    if (!clientSecret) {
-      return;
-    }
-
-    const body = new URLSearchParams();
-    body.append('grant_type', 'refresh_token');
-    body.append('client_id', clientId);
-    body.append('client_secret', clientSecret);
-    body.append('refresh_token', refreshToken);
-
-    const response = await fetch(`${url}/realms/${realm}/protocol/openid-connect/token`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      body: body.toString()
-    });
-
-    if (!response.ok) {
-      console.error('Could not refresh tokens: ' + response.status);
-      return false;
-    }
-
-    const data = await response.json();
-
-    proxyReq.setHeader('Authorization', `Bearer ${data.access_token}`);
-  }
-};
-
-const onProxyRes = (proxyRes: IncomingMessage) => {
-  // Remove some headers that would be duplicated otherwise.
-  delete proxyRes.headers['date'];
-  delete proxyRes.headers['transfer-encoding'];
-};
-
-const onProxyError = (error: Error) => {
-  console.error('Error while proxying a MDE backend events request: ', error);
-};
 
 export default defineConfig({
   plugins: [sveltekit()],
@@ -91,17 +8,6 @@ export default defineConfig({
     port: 5173,
     hmr: {
       host: 'localhost'
-    },
-    proxy: {
-      '/events': {
-        target: 'http://mde-backend:8080/',
-        changeOrigin: true,
-        configure: (proxy) => {
-          proxy.on('proxyReq', onProxyReq);
-          proxy.on('proxyRes', onProxyRes);
-          proxy.on('error', onProxyError);
-        }
-      }
     }
   }
 });


### PR DESCRIPTION
The vite proxy configuration isn't used in production, thus moving the proxy to a svelte kite route.

Please review @KaiVolland.