### PR TITLE
Allows multiple values for inspireTheme and topicCategory

### DIFF
--- a/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
+++ b/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
@@ -16,9 +16,9 @@
     checkedValue = checkedValueFromData || false;
   });
   const selectionValueFromData = $derived(getValue<string[]>(CATEGORY_KEY));
-  let selectionValue = $state<string[]>([]);
+  let selectionValue = $state<string[]>();
   $effect(() => {
-    selectionValue = selectionValueFromData || ['mobility'];
+    selectionValue = selectionValueFromData;
   });
 
   const checkedFieldConfig = getFieldConfig<string>(CHECKED_KEY);

--- a/src/lib/components/Form/Field/07_AnnexThemeField.svelte
+++ b/src/lib/components/Form/Field/07_AnnexThemeField.svelte
@@ -45,9 +45,9 @@
     if (!inspireIDs || inspireIDs.length === 0) return;
     const response = await fetch(`/data/iso_themes`);
     const data: IsoTheme[] = await response.json();
-    const matches = inspireIDs.map((inspireId) =>
-      data.find(entry => entry.inspireID === inspireId)?.isoID
-    ).filter(Boolean) as string[];
+    const matches = inspireIDs
+      .map((inspireId) => data.find((entry) => entry.inspireID === inspireId)?.isoID)
+      .filter(Boolean) as string[];
     const uniqueValues = Array.from(new Set(matches));
     return persistValue(TOPIC_KEY, uniqueValues);
   };
@@ -68,7 +68,7 @@
         label={fieldConfig?.label}
         {fieldConfig}
         options={OPTIONS}
-        value={(Array.isArray(value) && value.length > 0) ? value[0] : undefined}
+        value={Array.isArray(value) && value.length > 0 ? value[0] : undefined}
         onChange={(newValue) => onChange([newValue])}
         {validationResult}
       />

--- a/src/lib/components/Form/Field/13_TopicCategory.svelte
+++ b/src/lib/components/Form/Field/13_TopicCategory.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-  import {
-    getFieldConfig,
-    getValue,
-    persistValue,
-  } from '$lib/context/FormContext.svelte';
+  import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import type { IsoTheme } from '$lib/models/metadata';
   import type { ValidationResult } from '../FieldsConfig';
@@ -55,7 +51,7 @@
         label={fieldConfig?.label}
         {fieldConfig}
         options={OPTIONS}
-        value={value}
+        {value}
         {disabled}
         {onChange}
         {validationResult}

--- a/src/lib/components/Form/Field/13_TopicCategory.svelte
+++ b/src/lib/components/Form/Field/13_TopicCategory.svelte
@@ -1,21 +1,16 @@
 <script lang="ts">
   import {
-    FORMSTATE_CONTEXT,
     getFieldConfig,
     getValue,
     persistValue,
-    type FormState
   } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
-  import SelectInput from '../Inputs/SelectInput.svelte';
   import type { IsoTheme } from '$lib/models/metadata';
   import type { ValidationResult } from '../FieldsConfig';
   import { getContext } from 'svelte';
   import type { Token } from '$lib/models/keycloak';
   import { getHighestRole } from '$lib/util';
-
-  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
-  const metadata = $derived(formState.metadata);
+  import MultiSelectInput from '../Inputs/MultiSelectInput.svelte';
 
   const token = getContext<Token>('user_token');
   const highestRole = $derived(getHighestRole(token));
@@ -23,24 +18,16 @@
   const KEY = 'isoMetadata.topicCategory';
   const ANNEX_THEME_KEY = 'isoMetadata.inspireTheme';
 
-  const inspireTheme = $derived(getValue<string>(ANNEX_THEME_KEY, metadata));
-  const valueFromData = $derived(getValue<string>(KEY));
-  let value = $state('');
-  $effect(() => {
-    if (valueFromData) {
-      value = valueFromData;
-    }
-  });
-
-  $effect(() => {
-    getAutoFillValues(inspireTheme);
-  });
+  const value = $derived(getValue<string[]>(KEY));
+  const annexValue = $derived(getValue<string[]>(ANNEX_THEME_KEY));
 
   let showCheckmark = $state(false);
-  const fieldConfig = getFieldConfig<string>(KEY);
+  const fieldConfig = getFieldConfig<string[]>(KEY);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
-  const onChange = async (newValue?: string) => {
+  let disabled = $derived(!!annexValue?.length);
+
+  const onChange = async (newValue?: string[]) => {
     const response = await persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;
@@ -56,15 +43,7 @@
     }));
   };
 
-  const getAutoFillValues = async (inspireID?: string) => {
-    if (!inspireID) return;
-    const response = await fetch(`/data/iso_themes`);
-    const data = await response.json();
-    const match = data.find((entry: IsoTheme) => entry.inspireID === inspireID);
-    if (!match) return;
-    value = match.isoID;
-    onChange(value);
-  };
+  $inspect(disabled);
 </script>
 
 {#if highestRole !== 'MdeDataOwner'}
@@ -72,12 +51,12 @@
     {#await fetchOptions()}
       <p>Lade Themen Kategorien</p>
     {:then OPTIONS}
-      <SelectInput
+      <MultiSelectInput
         label={fieldConfig?.label}
         {fieldConfig}
         options={OPTIONS}
-        disabled={!!inspireTheme}
-        {value}
+        value={value}
+        {disabled}
         {onChange}
         {validationResult}
       />
@@ -92,7 +71,7 @@
     display: flex;
     gap: 0.25em;
 
-    :global(.select-input) {
+    :global(.multi-select-input) {
       flex: 1;
     }
 

--- a/src/lib/components/Form/Inputs/MultiSelectInput.svelte
+++ b/src/lib/components/Form/Inputs/MultiSelectInput.svelte
@@ -22,6 +22,7 @@
     label,
     class: wrapperClass,
     fieldConfig,
+    disabled = false,
     options,
     validationResult
   }: InputProps = $props();
@@ -81,22 +82,26 @@
     {#snippet chip(chip)}
       <Chip {chip} onSMUIChipRemoval={onRemove}>
         <Text>{chip.label}</Text>
-        <TrailingAction icon$class="material-icons">cancel</TrailingAction>
+        {#if !disabled}
+          <TrailingAction icon$class="material-icons">cancel</TrailingAction>
+        {/if}
       </Chip>
     {/snippet}
   </ChipSet>
-  <Autocomplete
-    options={filteredOptions}
-    bind:value={inputValue}
-    getOptionLabel={getLabel}
-    selectOnExactMatch={false}
-    showMenuWithNoInput
-    onSMUIAutocompleteSelected={onSelect}
-  >
-    {#snippet noMatches()}
-      <Text>Keine weiteren Optionen verfügbar</Text>
-    {/snippet}
-  </Autocomplete>
+  {#if !disabled}
+    <Autocomplete
+      options={filteredOptions}
+      bind:value={inputValue}
+      getOptionLabel={getLabel}
+      selectOnExactMatch={false}
+      showMenuWithNoInput
+      onSMUIAutocompleteSelected={onSelect}
+    >
+      {#snippet noMatches()}
+        <Text>Keine weiteren Optionen verfügbar</Text>
+      {/snippet}
+    </Autocomplete>
+  {/if}
   <FieldHint {validationResult} {fieldConfig} />
   <div class="field-footer">
     <FieldHint {validationResult} {fieldConfig} />
@@ -104,7 +109,7 @@
 </fieldset>
 
 <style lang="scss">
-  .multi-select-input {
+  :global(.multi-select-input) {
     padding-top: 1.2em;
     border-radius: 0.25rem;
     display: flex;
@@ -120,6 +125,10 @@
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
+    }
+
+    :global(.smui-autocomplete) {
+      justify-self: stretch;
     }
 
     :global(.mdc-text-field) {


### PR DESCRIPTION
This allows setting multiple values for `inspireTheme` and `topicCategory`.

It also adapts the logic auf prefilling values. It was moved from the target `topicCatgeory` to the source `inspireTheme`.

It makes use of the `MultiSelect` input.

This relies on: https://github.com/gdi-be/mde-backend/pull/67