### PR TITLE
Add missing fields termsOfUseSource and relatedTopics

### DIFF
--- a/src/lib/components/Form/Field/13_TopicCategory.svelte
+++ b/src/lib/components/Form/Field/13_TopicCategory.svelte
@@ -38,8 +38,6 @@
       label: entry.isoName
     }));
   };
-
-  $inspect(disabled);
 </script>
 
 {#if highestRole !== 'MdeDataOwner'}

--- a/src/lib/components/Form/Field/24_TermsOfUseField.svelte
+++ b/src/lib/components/Form/Field/24_TermsOfUseField.svelte
@@ -8,20 +8,10 @@
 
   const KEY = 'isoMetadata.termsOfUseId';
 
-  const valueFromData = $derived(getValue<string>(KEY));
-  let value = $state('');
-  $effect(() => {
-    value = valueFromData || '';
-  });
+  const value = $derived(getValue<number>(KEY));
 
   let showCheckmark = $state(false);
-  let termsOfUseList: TermsOfUse[] = $state([]);
-  const selectedDescription = $derived.by(() => {
-    const description = termsOfUseList.find((item) => item.id === Number(value))?.description;
-    if (!description) return '';
-    return description.replace(/{{(.*?)}}/g, (match, p1) => getValue(p1.trim()) || match);
-  });
-  const fieldConfig = getFieldConfig<string>(KEY);
+  const fieldConfig = getFieldConfig<number>(KEY);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const fetchOptions = async () => {
@@ -33,7 +23,6 @@
       }
       return a.active ? -1 : 1;
     });
-    termsOfUseList = data;
     return data;
   };
 
@@ -57,15 +46,19 @@
           (item: TermsOfUse): Option => ({
             key: item.id.toString(),
             label: item.shortname,
-            disabled: !item.active
+            disabled: !item.active,
+            description: item.description
           })
         )}
-        value={value.toString()}
+        value={value?.toString()}
         {onChange}
         {validationResult}
       />
-      {#if selectedDescription}
-        <p class="description">{selectedDescription}</p>
+      {#if value !== 1}
+        <p class="not-standard">
+          Die Nutzungsbedingungen weichen von den Standardnutzungsbedingungen ab. Dies sollte nur in
+          Ausnahmefällen und in Absprache mit einem Redakteur geschehen.
+        </p>
       {/if}
     </div>
   {/await}
@@ -86,9 +79,10 @@
       flex: 1;
     }
 
-    .description {
-      font-size: 0.75em;
-      color: var(--mdc-theme-secondary);
+    .not-standard {
+      font-size: 0.75rem;
+      color: var(--error-color);
+      margin: 1em;
     }
   }
 </style>

--- a/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
+++ b/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
+  import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
+  import FieldTools from '../FieldTools.svelte';
+  import type { ValidationResult } from '../FieldsConfig';
+
+  const KEY = 'isoMetadata.termsOfUseSource';
+  const TERMS_OF_USE_KEY = 'isoMetadata.termsOfUseId';
+
+  const valueFromData = $derived(getValue<string>(KEY));
+  const termsOfUseId = $derived(getValue<number>(TERMS_OF_USE_KEY));
+
+  let value = $state('');
+  $effect(() => {
+    value = valueFromData || '';
+  });
+
+  let showCheckmark = $state(false);
+  const fieldConfig = getFieldConfig<string>(KEY);
+  let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+
+  const onBlur = async () => {
+    const response = await persistValue(KEY, value);
+    if (response.ok) {
+      showCheckmark = true;
+    }
+  };
+</script>
+
+{#if termsOfUseId && termsOfUseId !== 1}
+  <div class="terms-of-use-source-field">
+    <TextInput
+      bind:value
+      label={fieldConfig?.label || KEY}
+      {fieldConfig}
+      {validationResult}
+      onblur={onBlur}
+    />
+    <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  </div>
+{/if}
+
+<style lang="scss">
+  .terms-of-use-source-field {
+    position: relative;
+    display: flex;
+    gap: 0.25em;
+
+    :global(.text-input) {
+      flex: 1;
+    }
+
+    :global(.mdc-text-field) {
+      display: flex;
+    }
+  }
+</style>

--- a/src/lib/components/Form/Field/36_RelatedTopicsField.svelte
+++ b/src/lib/components/Form/Field/36_RelatedTopicsField.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
+  import { getFieldConfig, getValue, persistValue } from '$lib/context/FormContext.svelte';
+  import { getContext } from 'svelte';
+  import FieldTools from '../FieldTools.svelte';
+  import type { ValidationResult } from '../FieldsConfig';
+  import type { Token } from '$lib/models/keycloak';
+  import { getHighestRole } from '$lib/util';
+
+  const KEY = 'clientMetadata.relatedTopics';
+
+  const valueFromData = $derived(getValue<string>(KEY));
+  let value = $state('');
+  $effect(() => {
+    value = valueFromData || '';
+  });
+
+  const token = getContext<Token>('user_token');
+  const highestRole = $derived(getHighestRole(token));
+
+  let showCheckmark = $state(false);
+  const fieldConfig = getFieldConfig<string>(KEY);
+  let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+
+  const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
+
+  const onBlur = async () => {
+    const response = await persistValue(KEY, value);
+    if (response.ok) {
+      showCheckmark = true;
+    }
+  };
+</script>
+
+{#if fieldVisible}
+  <div class="related-topics-field">
+    <TextInput
+      bind:value
+      label={fieldConfig?.label || KEY}
+      {fieldConfig}
+      {validationResult}
+      onblur={onBlur}
+    />
+    <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  </div>
+{/if}
+
+<style lang="scss">
+  .related-topics-field {
+    position: relative;
+    display: flex;
+    gap: 0.25em;
+
+    :global(.text-input) {
+      flex: 1;
+    }
+
+    :global(.mdc-text-field) {
+      display: flex;
+    }
+  }
+</style>

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -229,6 +229,16 @@ export const FieldConfigs: FieldConfig<any>[] = [
     required: true
   },
   {
+    profile_id: 26,
+    label: 'Nutzungsbestimmungen Quellenangabe',
+    key: 'isoMetadata.termsOfUseSource',
+    validator: () => {
+      return { valid: true };
+    },
+    section: 'classification',
+    required: true
+  },
+  {
     profile_id: 7,
     label: 'INSPIRE Annex Thema',
     key: 'isoMetadata.inspireTheme',
@@ -537,6 +547,16 @@ export const FieldConfigs: FieldConfig<any>[] = [
           helpText: 'Bitte geben Sie eine Herkunft an.'
         };
       }
+      return { valid: true };
+    },
+    section: 'additional',
+    required: false
+  },
+  {
+    profile_id: 36,
+    label: 'Verwandte Themen (MTK)',
+    key: 'clientMetadata.relatedTopics',
+    validator: () => {
       return { valid: true };
     },
     section: 'additional',

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -18,6 +18,7 @@
   import F05_InspireType from './Field/05_InspireType.svelte';
   import F04_PrivacyField from './Field/04_PrivacyField.svelte';
   import F24_TermsOfUseField from './Field/24_TermsOfUseField.svelte';
+  import F26_TermsOfUseSourceField from './Field/26_TermsOfUseSourceField.svelte';
   import F07_AnnexThemeField from './Field/07_AnnexThemeField.svelte';
   import F37_QualityReportCheckField from './Field/37_QualityReportCheckField.svelte';
   import F06_HighValueDatasetField from './Field/06_HighValueDatasetField.svelte';
@@ -34,6 +35,7 @@
   import F30_ContentDescription from './Field/30_ContentDescription.svelte';
   import F31_TechnicalDescription from './Field/31_TechnicalDescription.svelte';
   import F32_Lineage from './Field/32_Lineage.svelte';
+  import F36_RelatedTopicsField from './Field/36_RelatedTopicsField.svelte';
   import F39_AdditionalInformation from './Field/39_AdditionalInformation.svelte';
   import F38_InspireAnnexVersionField from './Field/38_InspireAnnexVersionField.svelte';
   import ServicesSection from './service/ServicesSection.svelte';
@@ -151,6 +153,7 @@
           <F05_InspireType />
           <F04_PrivacyField />
           <F24_TermsOfUseField />
+          <F26_TermsOfUseSourceField />
           <F07_AnnexThemeField />
           <F38_InspireAnnexVersionField />
           <F37_QualityReportCheckField />
@@ -178,6 +181,7 @@
           <F30_ContentDescription />
           <F31_TechnicalDescription />
           <F32_Lineage />
+          <F36_RelatedTopicsField />
           <F39_AdditionalInformation />
           <ScrollToTopButton target={formWrapper} />
         </section>

--- a/src/lib/components/Form/Inputs/SelectInput.svelte
+++ b/src/lib/components/Form/Inputs/SelectInput.svelte
@@ -34,11 +34,13 @@
   const onSelect = (newValue: string) => {
     onChange?.(newValue);
   };
+
+  const selectedDescription = $derived(options.find((item) => item.key === value)?.description);
 </script>
 
 <fieldset class={['select-input', wrapperClass]}>
   <legend>{label}</legend>
-  <Select bind:this={element} {disabled} hiddenInput menu$anchorElement={document.body} bind:value>
+  <Select bind:this={element} {disabled} menu$anchorElement={document.body} bind:value>
     {#each options as option}
       <SelectOption
         onSMUIAction={() => {
@@ -50,8 +52,12 @@
       >
         {option.label}
       </SelectOption>
+      {#if option.description}
+        <div class="option-description">{option.description}</div>
+      {/if}
     {/each}
   </Select>
+  <div class="selected-description">{selectedDescription}</div>
   <div class="field-footer">
     <FieldHint {validationResult} {fieldConfig} />
   </div>
@@ -85,6 +91,31 @@
         opacity: 0.5;
         pointer-events: none;
       }
+    }
+
+    :global(li:hover + .option-description) {
+      background-color: #f5f5f5;
+    }
+
+    :global(li[aria-selected='true'] + .option-description) {
+      background-color: #d6d6d6;
+      color: black;
+    }
+
+    .option-description {
+      font-size: 0.66em;
+      color: grey;
+      padding-left: 3em;
+      padding-bottom: 1em;
+      line-height: 1em;
+      border-bottom: 1px solid lightgrey;
+    }
+
+    .selected-description {
+      font-size: 0.66em;
+      color: grey;
+      padding: 0.5em;
+      line-height: 1em;
     }
   }
 </style>

--- a/src/lib/components/Form/service/ServiceForm.svelte
+++ b/src/lib/components/Form/service/ServiceForm.svelte
@@ -10,11 +10,7 @@
   import DownloadForm from './DownloadForm.svelte';
   import FeatureTypeForm from './FeatureTypeForm.svelte';
   import { getContext } from 'svelte';
-  import {
-    FORMSTATE_CONTEXT,
-    getSubFieldConfig,
-    type FormState
-  } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import LayersForm from './LayersForm.svelte';
   import { page } from '$app/state';
 
@@ -91,8 +87,6 @@
 
     layerCheckmarkVisible = response.ok;
   }
-
-  $inspect(getSubFieldConfig('isoMetadata.services', 'title'));
 </script>
 
 <div class="service-form">

--- a/src/lib/models/form.ts
+++ b/src/lib/models/form.ts
@@ -13,6 +13,7 @@ export type Option = {
   disabled?: boolean;
   key: string;
   label: string;
+  description?: string;
 };
 
 /**


### PR DESCRIPTION
This adds some missing fields to the form:

- `clientMetadata.termsOfUseSource` -> "Quelle-NB" (26)
- `isoMetadata.relatedTopics` -> "Verwandte Themen (MTK)" (36)

It also adjusts the layout of the `termsOfUseId` --> Nuztungsbestimmungen (25)