### PR TITLE
Introduces button to use the value of the original dataset

### DIFF
--- a/src/lib/components/Form/Field/13_TopicCategory.svelte
+++ b/src/lib/components/Form/Field/13_TopicCategory.svelte
@@ -25,8 +25,6 @@
 
   let disabled = $derived(!!annexValue?.length && profileValue !== 'ISO');
 
-  $inspect(annexValue?.length, profileValue, disabled);
-
   const onChange = async (newValue?: string[]) => {
     const response = await persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/FieldTools.svelte
+++ b/src/lib/components/Form/FieldTools.svelte
@@ -63,7 +63,7 @@
     {#await getValueFromOriginal()}
       <Icon
         class="material-icons spinner"
-        title="Es wird geprüft ob der Wert im Originaldatensatz gesetzt war."
+        title="Es wird geprüft, ob der Wert im Originaldatensatz gesetzt ist."
       >
         progress_activity
       </Icon>

--- a/src/lib/components/Form/FieldTools.svelte
+++ b/src/lib/components/Form/FieldTools.svelte
@@ -2,8 +2,10 @@
   import Checkmark from './Checkmark.svelte';
   import HelpButton from './HelpButton.svelte';
   import CopyButton from './CopyButton.svelte';
-  import type { Snippet } from 'svelte';
+  import { type Snippet } from 'svelte';
   import { Icon } from '@smui/button';
+  import { getFormContext, getValue, persistValue } from '$lib/context/FormContext.svelte';
+  import IconButton from '@smui/icon-button';
 
   export type FieldToolsProps = {
     key: string;
@@ -23,10 +25,22 @@
     noCopyButton = false
   }: FieldToolsProps = $props();
 
+  const metadata = $derived(getFormContext()?.metadata);
+
   const checkIfHasHelp = async () => {
     const response = await fetch(`/help/${key}`);
     if (!response.ok || response.status === 204) return false;
     return true;
+  };
+
+  const getValueFromOriginal = async () => {
+    const response = await fetch(`/metadata/${metadata?.clonedFromId}`, {
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+    const originalMetadata = await response.json();
+    return getValue(key, originalMetadata);
   };
 </script>
 
@@ -44,6 +58,31 @@
   {/await}
   {#if !noCopyButton}
     <CopyButton {key} />
+  {/if}
+  {#if metadata?.clonedFromId}
+    {#await getValueFromOriginal()}
+      <Icon
+        class="material-icons spinner"
+        title="Es wird geprüft ob der Wert im Originaldatensatz gesetzt war."
+      >
+        progress_activity
+      </Icon>
+    {:then valueFromOriginal}
+      {#if valueFromOriginal}
+        <IconButton
+          type="button"
+          size="button"
+          title="Wert aus Originaldatensatz übernehmen"
+          onclick={() => persistValue(key, valueFromOriginal)}
+        >
+          <Icon class="material-icons">settings_backup_restore</Icon>
+        </IconButton>
+      {/if}
+    {:catch}
+      <Icon class="material-icons" title="Fehler beim Prüfen des Originaldatensatzes.">
+        warning
+      </Icon>
+    {/await}
   {/if}
   {@render children?.()}
   {#if !noCheckmark}

--- a/src/lib/models/metadata.ts
+++ b/src/lib/models/metadata.ts
@@ -215,6 +215,7 @@ export type Contacts = Contact[];
 
 export type MetadataCollection = {
   id?: string;
+  clonedFromId?: string;
   metadataId?: MetadataId;
   teamMemberIds?: string[];
   assignedUserId?: string;

--- a/src/routes/metadata/[metadataid]/+server.ts
+++ b/src/routes/metadata/[metadataid]/+server.ts
@@ -1,6 +1,19 @@
 import { error, json } from '@sveltejs/kit';
 import { getAccessToken } from '$lib/auth/cookies.js';
 import { deleteMetadataCollection, updateDataValue } from '$lib/api/metadata.js';
+import { getMetadataCollectionByMetadataId } from '$lib/api/metadata.js';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ cookies, params }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+  if (!params.metadataid) return error(404, 'Not Found');
+
+  const metadata = await getMetadataCollectionByMetadataId(params.metadataid, token);
+  if (!metadata) return error(404, `Metadata with ID ${params.metadataid} could not be found`);
+
+  return json(metadata);
+}
 
 /** @type {import('./$types').RequestHandler} */
 export async function PATCH({ cookies, request, params }) {


### PR DESCRIPTION
This introduces a button to get the value from the original dataset. The button is located in the field tools and only visible if the dataset has a `clonedFromId`.

:warning: relies on https://github.com/gdi-be/mde-backend/pull/82