### PR TITLE
Add CSS for thumbnail in help

### DIFF
--- a/src/lib/components/Form/HelpPanel.svelte
+++ b/src/lib/components/Form/HelpPanel.svelte
@@ -29,5 +29,15 @@
     overflow: auto;
     flex: 1;
     padding: 0 3rem;
+
+    :global(img.thumbnail) {
+      max-width: 100%;
+      height: auto;
+      padding: 0.5rem;
+
+      &:hover {
+        outline: 1px solid var(--primary-color);
+      }
+    }
   }
 </style>


### PR DESCRIPTION
This adds CSS rules to be able to add large images to a help markdown as a thumbnail:

```html
<a href="https://raw.githubusercontent.com/gdi-be/mde-deployment/refs/heads/main/codelists/help/previews/description.png" target="_blank">
  <img class="thumbnail" src="https://raw.githubusercontent.com/gdi-be/mde-deployment/refs/heads/main/codelists/help/previews/description.png">
</a>
```


##Preview

![gdi_berlin_mde-help-thumbnail](https://github.com/user-attachments/assets/b1cdada3-6034-4b50-87fc-2eefe5bd7758)
