### PR TITLE
Fix clipboard copy behavior and add confirmation for original value copy

### DIFF
--- a/src/lib/components/Form/CopyButton.svelte
+++ b/src/lib/components/Form/CopyButton.svelte
@@ -11,7 +11,13 @@
 
   const copyValue = async () => {
     try {
-      await navigator.clipboard.writeText(JSON.stringify(value));
+      let text = JSON.stringify(value);
+      // remove quotes from the string if it's a stringified object
+      if (text.startsWith('"') && text.endsWith('"')) {
+        text = text.slice(1, -1);
+      }
+
+      await navigator.clipboard.writeText(text);
       copied = true;
       setTimeout(() => (copied = false), 500);
     } catch (error) {

--- a/src/lib/components/Form/FieldTools.svelte
+++ b/src/lib/components/Form/FieldTools.svelte
@@ -66,7 +66,7 @@
         }
       );
     } else {
-      toast.error('Kein Wert im Vorlagedatensatzes gefunden');
+      toast.error('Kein Wert im Vorlagedatensatz gefunden');
     }
   };
 </script>
@@ -90,7 +90,7 @@
     {#await getValueFromOriginal()}
       <Icon
         class="material-icons spinner"
-        title="Es wird geprüft, ob der Wert im Vorlagedatensatzes gesetzt ist."
+        title="Es wird geprüft, ob der Wert im Vorlagedatensatz gesetzt ist."
       >
         progress_activity
       </Icon>
@@ -99,7 +99,7 @@
         <IconButton
           type="button"
           size="button"
-          title="Wert aus Vorlagedatensatzes übernehmen"
+          title="Wert aus Vorlagedatensatz übernehmen"
           onclick={(evt) => copyFromOriginal(key, valueFromOriginal, evt)}
         >
           <Icon class="material-icons">settings_backup_restore</Icon>

--- a/src/lib/components/Form/FieldTools.svelte
+++ b/src/lib/components/Form/FieldTools.svelte
@@ -7,6 +7,7 @@
   import { getFormContext, getValue, persistValue } from '$lib/context/FormContext.svelte';
   import IconButton from '@smui/icon-button';
   import { toast } from 'svelte-french-toast';
+  import { popconfirm } from '../../context/PopConfirmContex.svelte';
 
   export type FieldToolsProps = {
     key: string;
@@ -49,6 +50,25 @@
     const originalMetadata = await response.json();
     return getValue(key, originalMetadata);
   };
+
+  const copyFromOriginal = async (k: string, valueFromOriginal: unknown, evt: MouseEvent) => {
+    if (valueFromOriginal) {
+      const targetEl = evt.currentTarget as HTMLElement;
+      evt.preventDefault();
+      popconfirm(
+        targetEl,
+        async () => {
+          await persistValue(k, valueFromOriginal);
+        },
+        {
+          text: 'Möchten Sie den Werte wirklich aus der Vorlage übernehmen? Änderungen gehen verloren.',
+          confirmButtonText: 'Übernehmen'
+        }
+      );
+    } else {
+      toast.error('Kein Wert im Vorlagedatensatzes gefunden');
+    }
+  };
 </script>
 
 <div class="field-tools">
@@ -70,7 +90,7 @@
     {#await getValueFromOriginal()}
       <Icon
         class="material-icons spinner"
-        title="Es wird geprüft, ob der Wert im Originaldatensatz gesetzt ist."
+        title="Es wird geprüft, ob der Wert im Vorlagedatensatzes gesetzt ist."
       >
         progress_activity
       </Icon>
@@ -79,16 +99,14 @@
         <IconButton
           type="button"
           size="button"
-          title="Wert aus Originaldatensatz übernehmen"
-          onclick={() => persistValue(key, valueFromOriginal)}
+          title="Wert aus Vorlagedatensatzes übernehmen"
+          onclick={(evt) => copyFromOriginal(key, valueFromOriginal, evt)}
         >
           <Icon class="material-icons">settings_backup_restore</Icon>
         </IconButton>
       {/if}
     {:catch}
-      <Icon class="material-icons" title="Fehler beim Prüfen des Originaldatensatzes.">
-        warning
-      </Icon>
+      <Icon class="material-icons" title="Fehler beim Prüfen des Vorlagedatensatzes.">warning</Icon>
     {/await}
   {/if}
   {@render children?.()}

--- a/src/lib/components/Form/FieldTools.svelte
+++ b/src/lib/components/Form/FieldTools.svelte
@@ -61,7 +61,7 @@
           await persistValue(k, valueFromOriginal);
         },
         {
-          text: 'Möchten Sie den Werte wirklich aus der Vorlage übernehmen? Änderungen gehen verloren.',
+          text: 'Möchten Sie den Wert wirklich aus der Vorlage übernehmen? Änderungen gehen verloren.',
           confirmButtonText: 'Übernehmen'
         }
       );

--- a/src/lib/components/Form/service/LayersForm.svelte
+++ b/src/lib/components/Form/service/LayersForm.svelte
@@ -56,6 +56,7 @@
       }
     ];
     activeTabIndex = layers.length - 1;
+    onChange(layers);
   }
 
   function removeLayer(index: number, evt: MouseEvent) {

--- a/src/lib/components/Form/service/ServiceForm.svelte
+++ b/src/lib/components/Form/service/ServiceForm.svelte
@@ -89,7 +89,7 @@
     }
 
     layerCheckmarkVisible = response.ok;
-    // TODO: update progress bar
+    invalidateAll();
   }
 </script>
 


### PR DESCRIPTION
- Improve the copy functionality by removing unnecessary quotes from copied values.
- Introduce a confirmation dialog for the "copy from original" action to prevent accidental overwrites.
- Fix progress updates in the LayersForm to ensure accurate state representation.