### PR TITLE
Adapt assignment button visibility logic

### DIFF
--- a/src/lib/models/metadata.ts
+++ b/src/lib/models/metadata.ts
@@ -215,6 +215,7 @@ export type Contacts = Contact[];
 
 export type MetadataCollection = {
   id?: string;
+  ownerId?: string;
   clonedFromId?: string;
   metadataId?: MetadataId;
   teamMemberIds?: string[];


### PR DESCRIPTION
Enhance the visibility logic for the assignment button based on user roles and ownership status. This change ensures that only eligible users can see and use the assignment functionality.

Relies on https://github.com/gdi-be/mde-backend/pull/111