### PR TITLE
Use label from config for layers legend

### DIFF
--- a/src/lib/components/Form/service/LayersForm.svelte
+++ b/src/lib/components/Form/service/LayersForm.svelte
@@ -96,7 +96,7 @@
 </script>
 
 <fieldset class="layers-form">
-  <legend> Layers </legend>
+  <legend>{fieldConfig?.label || 'Layers'} </legend>
   <FieldHint {fieldConfig} {validationResult} />
   <nav>
     {#each tabs as tab, i}


### PR DESCRIPTION
Update the layers fieldset legend to use a label from the configuration, providing better customization options.