### PR TITLE
Update phone number validation logic and messages

### DIFF
--- a/src/lib/components/Form/Field/25_TermsOfUseField.svelte
+++ b/src/lib/components/Form/Field/25_TermsOfUseField.svelte
@@ -47,7 +47,7 @@
   {:then OPTIONS}
     <div class="input-wrapper">
       <SelectInput
-        label={fieldConfig?.label}
+        label={fieldConfig?.label || KEY}
         fieldConfig={fieldConfig as unknown as FullFieldConfig<string>}
         options={OPTIONS.map(
           (item: TermsOfUse): Option => ({

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -53,7 +53,7 @@ const isDefined = <T>(val: T): val is NonNullable<T> => {
 };
 
 const isValidPhoneNumber = (val: string) => {
-  const numberRegex = /^[+]?[0-9\s]+$/;
+  const numberRegex = /^[0-9]+$/;
   return numberRegex.test(val);
 };
 
@@ -498,7 +498,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       if (!isValidPhoneNumber(val)) {
         return {
           valid: false,
-          helpText: 'Bitte geben Sie eine gültige Telefonnummer an.'
+          helpText: 'Bitte geben Sie eine gültige Telefonnummer an. Es sind ausschließlich Zahlen erlaubt.'
         };
       }
       return { valid: true };


### PR DESCRIPTION
Refine phone number validation to allow only numeric characters and update the help text to reflect this change.