### PR TITLE
Add INSPIRE fieldset for metadata types

### DIFF
--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -117,7 +117,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
   },
   {
     profileId: 5,
-    label: 'INSPIRE Relevanz',
+    label: 'Metadaten-Typ',
     key: 'isoMetadata.metadataProfile',
     validator: (val: any) => {
       if (!isDefined(val)) {

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -167,12 +167,15 @@
       {/if}
       {#if activeSection === 'classification'}
         <section id="classification" transition:fade>
-          <F05_InspireType />
+          <fieldset class="inspire-fieldset">
+            <legend>INSPIRE Relevanz</legend>
+            <F05_InspireType />
+            <F07_AnnexThemeField />
+            <F38_InspireAnnexVersionField />
+          </fieldset>
           <F04_PrivacyField />
           <F25_TermsOfUseField />
           <F26_TermsOfUseSourceField />
-          <F07_AnnexThemeField />
-          <F38_InspireAnnexVersionField />
           <F37_QualityReportCheckField />
           <F06_HighValueDatasetField />
           <F13_TopicCategory />
@@ -247,6 +250,35 @@
     display: flex;
     flex-direction: column;
     align-self: stretch;
+
+    fieldset.inspire-fieldset {
+      padding-top: 1.2em;
+      border-radius: 0.25rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 1em;
+
+      legend {
+        font-size: 1.5em;
+      }
+
+      :global(.text-input),
+      :global(.select-input),
+      :global(.multi-select-input) {
+        border: none;
+        background-color: rgba(244, 244, 244, 0.7);
+      }
+
+      :global(.text-input > legend),
+      :global(.select-input > legend),
+      :global(.multi-select-input > legend) {
+        font-size: 1.2em;
+        background-color: white;
+        border-radius: 0.25em;
+        padding: 0 0.25em;
+      }
+    }
 
     nav.tabs {
       display: flex;


### PR DESCRIPTION
Introduce a new fieldset for INSPIRE fields to enhance the metadata input section, improving organization and user experience. Update the label for the metadata profile accordingly.

## Preview

![image](https://github.com/user-attachments/assets/d41013f3-aa6e-4f5c-bab1-253285e81471)
