### PR TITLE
Prevent resizing of comments input

### DIFF
--- a/src/lib/components/Form/CommentsPanel.svelte
+++ b/src/lib/components/Form/CommentsPanel.svelte
@@ -126,6 +126,7 @@
             variant="outlined"
             input$maxlength={500}
             input$rows={inputRows}
+            input$resizable={false}
             bind:value
             label="Neuer Kommentar"
           >


### PR DESCRIPTION
Disable resizing for the comments input field to enhance user experience.