### PR TITLE
Update validation error color for optional fields

### DIFF
--- a/src/lib/components/Form/FieldHint.svelte
+++ b/src/lib/components/Form/FieldHint.svelte
@@ -31,7 +31,14 @@
   });
 </script>
 
-<span class={['field-hint', highestRole.toLowerCase(), isValid ? 'valid' : 'invalid']}>
+<span
+  class={[
+    'field-hint',
+    highestRole.toLowerCase(),
+    isValid ? 'valid' : 'invalid',
+    fieldConfig?.required ? 'required' : ''
+  ]}
+>
   {text}
 </span>
 
@@ -40,7 +47,11 @@
     font-size: var(--mdc-typography-caption-font-size, 0.75rem);
 
     &.invalid {
-      color: var(--mdc-theme-error);
+      color: var(--mdc-theme-secondary);
+
+      &.required {
+        color: var(--mdc-theme-error);
+      }
     }
   }
 </style>


### PR DESCRIPTION
Change the validation error color for optional fields to a secondary color, while ensuring required fields still display the error color appropriately.