### PR TITLE
Open links in new tab for published catalog records

### DIFF
--- a/src/lib/components/Form/PublishDialog.svelte
+++ b/src/lib/components/Form/PublishDialog.svelte
@@ -105,8 +105,10 @@
           <ul>
             {#each responseUuids?.publishedCatalogRecords ?? [] as uuid}
               <li>
-                <a href={`${env.PUBLIC_GNOS_URL}/srv/eng/catalog.search#/metadata/${uuid}`}
-                  >{uuid}</a
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={`${env.PUBLIC_GNOS_URL}/srv/eng/catalog.search#/metadata/${uuid}`}>{uuid}</a
                 >
               </li>
             {/each}


### PR DESCRIPTION
Links for published catalog records now open in a new tab, enhancing user navigation.