### PR TITLE
Allow self-assigning when responsibleRole is null

### DIFF
--- a/src/lib/components/Overview/MetadataCard.svelte
+++ b/src/lib/components/Overview/MetadataCard.svelte
@@ -50,7 +50,7 @@
     // or if i have the role "editor" or "quality assurance" i can assign
     else if (
       !assignedToSomeoneElse &&
-      metadata.responsibleRole === highestRole &&
+      (metadata.responsibleRole === highestRole || !metadata.responsibleRole) &&
       (isOwner || isTeamMember || ['MdeEditor', 'MdeQualityAssurance'].includes(highestRole))
     ) {
       return true;


### PR DESCRIPTION
Enable self-assigning of tasks even when the responsible role is not defined.