### PR TITLE
Add copy functionality across various fields

### DIFF
--- a/src/lib/components/Form/CopyButton.svelte
+++ b/src/lib/components/Form/CopyButton.svelte
@@ -28,10 +28,10 @@
           toast.error('Fehler beim Abrufen des Wertes für die Zwischenablage.');
           return;
         }
-      } else {
+      } else if (value) {
         text = JSON.stringify(value);
         // remove quotes from the string if it's a stringified object
-        if (text.startsWith('"') && text.endsWith('"')) {
+        if (text?.startsWith('"') && text?.endsWith('"')) {
           text = text.slice(1, -1);
         }
       }

--- a/src/lib/components/Form/CopyButton.svelte
+++ b/src/lib/components/Form/CopyButton.svelte
@@ -29,7 +29,16 @@
           return;
         }
       } else if (value) {
-        text = JSON.stringify(value);
+        if (typeof value === 'string') {
+          text = value;
+        } else if (typeof value === 'number') {
+          text = value.toString();
+        } else if (typeof value === 'boolean') {
+          text = value ? 'Ja' : 'Nein';
+        } else {
+          // Fallback for other types, e.g., objects
+          text = JSON.stringify(value);
+        }
         // remove quotes from the string if it's a stringified object
         if (text?.startsWith('"') && text?.endsWith('"')) {
           text = text.slice(1, -1);

--- a/src/lib/components/Form/CopyButton.svelte
+++ b/src/lib/components/Form/CopyButton.svelte
@@ -2,8 +2,16 @@
   import IconButton from '@smui/icon-button';
   import { Icon } from '@smui/button';
   import { getValue } from '$lib/context/FormContext.svelte';
+  import type { FieldKey } from '$lib/models/form';
+  import type { FullFieldConfig } from './FieldsConfig';
+  import toast from 'svelte-french-toast';
 
-  let { key } = $props();
+  export type CopyButtonProps = {
+    key: FieldKey;
+    fieldConfig?: FullFieldConfig;
+  };
+
+  let { key, fieldConfig }: CopyButtonProps = $props();
 
   const value = $derived(getValue(key));
   let copied = $state(false);
@@ -11,10 +19,21 @@
 
   const copyValue = async () => {
     try {
-      let text = JSON.stringify(value);
-      // remove quotes from the string if it's a stringified object
-      if (text.startsWith('"') && text.endsWith('"')) {
-        text = text.slice(1, -1);
+      let text = '';
+
+      if (fieldConfig?.getCopyValue) {
+        try {
+          text = await fieldConfig.getCopyValue(value);
+        } catch {
+          toast.error('Fehler beim Abrufen des Wertes für die Zwischenablage.');
+          return;
+        }
+      } else {
+        let text = JSON.stringify(value);
+        // remove quotes from the string if it's a stringified object
+        if (text.startsWith('"') && text.endsWith('"')) {
+          text = text.slice(1, -1);
+        }
       }
 
       await navigator.clipboard.writeText(text);

--- a/src/lib/components/Form/CopyButton.svelte
+++ b/src/lib/components/Form/CopyButton.svelte
@@ -29,7 +29,7 @@
           return;
         }
       } else {
-        let text = JSON.stringify(value);
+        text = JSON.stringify(value);
         // remove quotes from the string if it's a stringified object
         if (text.startsWith('"') && text.endsWith('"')) {
           text = text.slice(1, -1);

--- a/src/lib/components/Form/Field/04_PrivacyField.svelte
+++ b/src/lib/components/Form/Field/04_PrivacyField.svelte
@@ -51,7 +51,7 @@
       {onChange}
     />
   {/await}
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools key={KEY} {fieldConfig} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/05_MetadataProfileField.svelte
+++ b/src/lib/components/Form/Field/05_MetadataProfileField.svelte
@@ -6,7 +6,7 @@
   import type { ValidationResult } from '../FieldsConfig';
 
   const KEY = 'isoMetadata.metadataProfile';
-  const OPTIONS: {
+  export const MetadataProfileOptions: {
     key: MetadataProfile;
     label: string;
   }[] = [
@@ -44,13 +44,13 @@
 <div class="metadata-type-field">
   <SelectInput
     label={fieldConfig?.label}
-    options={OPTIONS}
+    options={MetadataProfileOptions}
     {fieldConfig}
     {value}
     {onChange}
     {validationResult}
   />
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/07_AnnexThemeField.svelte
+++ b/src/lib/components/Form/Field/07_AnnexThemeField.svelte
@@ -108,7 +108,7 @@
         {validationResult}
       />
     {/await}
-    <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/Field/07_AnnexThemeField.svelte
+++ b/src/lib/components/Form/Field/07_AnnexThemeField.svelte
@@ -90,7 +90,7 @@
         {validationResult}
       />
     {/await}
-    <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/Field/09_CreatedField.svelte
+++ b/src/lib/components/Form/Field/09_CreatedField.svelte
@@ -35,7 +35,7 @@
     onchange={onChange}
     {validationResult}
   />
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/10_PublishedField.svelte
+++ b/src/lib/components/Form/Field/10_PublishedField.svelte
@@ -59,7 +59,7 @@
     onchange={onChange}
     {validationResult}
   />
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/11_LastUpdatedField.svelte
+++ b/src/lib/components/Form/Field/11_LastUpdatedField.svelte
@@ -54,7 +54,7 @@
     {fieldConfig}
     {validationResult}
   />
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -33,7 +33,8 @@
 
   const onChange = async (key: string) => {
     const value = key === FROM_KEY ? startValue : endValue!;
-    const response = await persistValue(key, new Date(value!).toISOString());
+    const valueToPersist = value ? new Date(value).toISOString() : null;
+    const response = await persistValue(key, valueToPersist);
     if (response.ok) {
       showCheckmark = true;
     }
@@ -59,7 +60,11 @@
       validationResult={toValidationResult}
     />
   </fieldset>
-  <FieldTools key={FROM_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools
+    fieldConfig={fromFieldConfig}
+    key={FROM_KEY}
+    bind:checkMarkAnmiationRunning={showCheckmark}
+  />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/13_TopicCategory.svelte
+++ b/src/lib/components/Form/Field/13_TopicCategory.svelte
@@ -63,7 +63,7 @@
         {validationResult}
       />
     {/await}
-    <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
+++ b/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
@@ -72,7 +72,7 @@
     {onChange}
     {validationResult}
   />
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/15_KeywordsField.svelte
+++ b/src/lib/components/Form/Field/15_KeywordsField.svelte
@@ -167,7 +167,7 @@
     </Autocomplete>
     <FieldHint {validationResult} {fieldConfig} />
   </fieldset>
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark}></FieldTools>
+  <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark}></FieldTools>
 </div>
 
 <Dialog

--- a/src/lib/components/Form/Field/18_ExtentField.svelte
+++ b/src/lib/components/Form/Field/18_ExtentField.svelte
@@ -181,7 +181,7 @@
         </div>
       </div>
     </fieldset>
-    <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -229,7 +229,6 @@
 
       .subfield-wrapper {
         display: flex;
-        gap: 0.5em;
 
         :global(.text-input) {
           flex: 1;

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -148,42 +148,59 @@
             delete
           </IconButton>
         </legend>
-        <TextInput
-          bind:value={contact.name}
-          label="Name"
-          onblur={persistContacts}
-          fieldConfig={getFieldConfig(20)}
-          validationResult={getFieldConfig(20)?.validator(contact.name)}
-          id={`${KEY}-${index}-name`}
-        />
-        <TextInput
-          bind:value={contact.organisation}
-          label="Organisation"
-          onblur={persistContacts}
-          fieldConfig={getFieldConfig(21)}
-          validationResult={getFieldConfig(21)?.validator(contact.organisation)}
-          id={`${KEY}-${index}-organisation`}
-        />
-        <TextInput
-          bind:value={contact.phone}
-          label="Telefon"
-          onblur={persistContacts}
-          fieldConfig={getFieldConfig(23)}
-          validationResult={getFieldConfig(23)?.validator(contact.phone)}
-          id={`${KEY}-${index}-phone`}
-        />
-        <TextInput
-          bind:value={contact.email}
-          label="E-Mail"
-          onblur={persistContacts}
-          fieldConfig={getFieldConfig(22)}
-          validationResult={getFieldConfig(22)?.validator(contact.email)}
-          id={`${KEY}-${index}-email`}
-        />
+        <div class="subfield-wrapper">
+          <TextInput
+            bind:value={contact.name}
+            label="Name"
+            onblur={persistContacts}
+            fieldConfig={getFieldConfig(20)}
+            validationResult={getFieldConfig(20)?.validator(contact.name)}
+            id={`${KEY}-${index}-name`}
+          />
+          <FieldTools key={`${KEY}[${index}].name`} noHelpButton noCheckmark {fieldConfig} />
+        </div>
+        <div class="subfield-wrapper">
+          <TextInput
+            bind:value={contact.organisation}
+            label="Organisation"
+            onblur={persistContacts}
+            fieldConfig={getFieldConfig(21)}
+            validationResult={getFieldConfig(21)?.validator(contact.organisation)}
+            id={`${KEY}-${index}-organisation`}
+          />
+          <FieldTools
+            key={`${KEY}[${index}].organisation`}
+            noHelpButton
+            noCheckmark
+            {fieldConfig}
+          />
+        </div>
+        <div class="subfield-wrapper">
+          <TextInput
+            bind:value={contact.phone}
+            label="Telefon"
+            onblur={persistContacts}
+            fieldConfig={getFieldConfig(23)}
+            validationResult={getFieldConfig(23)?.validator(contact.phone)}
+            id={`${KEY}-${index}-phone`}
+          />
+          <FieldTools key={`${KEY}[${index}].phone`} noHelpButton noCheckmark {fieldConfig} />
+        </div>
+        <div class="subfield-wrapper">
+          <TextInput
+            bind:value={contact.email}
+            label="E-Mail"
+            onblur={persistContacts}
+            fieldConfig={getFieldConfig(22)}
+            validationResult={getFieldConfig(22)?.validator(contact.email)}
+            id={`${KEY}-${index}-email`}
+          />
+          <FieldTools key={`${KEY}[${index}].email`} noHelpButton noCheckmark {fieldConfig} />
+        </div>
       </fieldset>
     {/each}
   </fieldset>
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
+  <FieldTools noCopyButton key={KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
     <AutoFillButton title="Eigene Kontaktdaten übernehmen" onclick={autoFillUserDetails} />
   </FieldTools>
 </div>
@@ -209,6 +226,15 @@
       display: flex;
       flex-direction: column;
       gap: 1em;
+
+      .subfield-wrapper {
+        display: flex;
+        gap: 0.5em;
+
+        :global(.text-input) {
+          flex: 1;
+        }
+      }
 
       legend {
         text-align: right;

--- a/src/lib/components/Form/Field/25_TermsOfUseField.svelte
+++ b/src/lib/components/Form/Field/25_TermsOfUseField.svelte
@@ -69,7 +69,7 @@
       {/if}
     </div>
   {/await}
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools key={KEY} {fieldConfig} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -106,7 +106,11 @@
       />
     {/if}
   </fieldset>
-  <FieldTools key={RESOLUTION_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools
+    fieldConfig={selected === SCALE_KEY ? scaleFieldConfig : resolutionFieldConfig}
+    key={selected === SCALE_KEY ? SCALE_KEY : RESOLUTION_KEY}
+    bind:checkMarkAnmiationRunning={showCheckmark}
+  />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -170,7 +170,7 @@
       </IconButton>
     </legend>
     <FieldHint {fieldConfig} />
-    {#each lineages as lineage (lineage.listId)}
+    {#each lineages as lineage, index (lineage.listId)}
       <fieldset class="lineage">
         <legend>
           <IconButton
@@ -183,14 +183,17 @@
           </IconButton>
         </legend>
         <div class="search-input-wrapper">
-          <TextInput
-            bind:value={lineage.title}
-            label="Titel"
-            onblur={onTitleBlur}
-            onkeyup={(evt) => onTitleKeyUp(evt, lineage)}
-            fieldConfig={getFieldConfig(33)}
-            validationResult={getFieldConfig(33)?.validator(lineage.title)}
-          />
+          <div class="wrap">
+            <TextInput
+              bind:value={lineage.title}
+              label="Titel"
+              onblur={onTitleBlur}
+              onkeyup={(evt) => onTitleKeyUp(evt, lineage)}
+              fieldConfig={getFieldConfig(33)}
+              validationResult={getFieldConfig(33)?.validator(lineage.title)}
+            />
+            <FieldTools key={`${KEY}[${index}].title`} fieldConfig={getFieldConfig(33)} />
+          </div>
           {#if metadataCollections.length > 0 && titleSearchListId === lineage.listId}
             <ul class="search-results" bind:this={searchResultsElement}>
               {#each metadataCollections as metadataCollection}
@@ -204,28 +207,32 @@
           {/if}
         </div>
         <div class="inline-fields">
-          <DateInput
-            class="publish-date-field"
-            bind:value={lineage.date}
-            key={KEY}
-            label="Veröffentlichungsdatum"
-            onblur={persistLineages}
-            fieldConfig={getFieldConfig(34)}
-            validationResult={getFieldConfig(34)?.validator(lineage.date)}
-          />
-          <TextInput
-            class="lineage-source-field"
-            bind:value={lineage.identifier}
-            label="Identifier"
-            onblur={persistLineages}
-            fieldConfig={getFieldConfig(35)}
-            validationResult={getFieldConfig(35)?.validator(lineage.identifier)}
-          />
+          <div class="publish-date-field">
+            <DateInput
+              bind:value={lineage.date}
+              key={KEY}
+              label="Veröffentlichungsdatum"
+              onblur={persistLineages}
+              fieldConfig={getFieldConfig(34)}
+              validationResult={getFieldConfig(34)?.validator(lineage.date)}
+            />
+            <FieldTools key={`${KEY}[${index}].date`} fieldConfig={getFieldConfig(34)} />
+          </div>
+          <div class="lineage-source-field">
+            <TextInput
+              bind:value={lineage.identifier}
+              label="Identifier"
+              onblur={persistLineages}
+              fieldConfig={getFieldConfig(35)}
+              validationResult={getFieldConfig(35)?.validator(lineage.identifier)}
+            />
+            <FieldTools key={`${KEY}[${index}].identifier`} fieldConfig={getFieldConfig(35)} />
+          </div>
         </div>
       </fieldset>
     {/each}
   </fieldset>
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">
@@ -238,6 +245,14 @@
       position: relative;
       display: flex;
       flex-direction: column;
+
+      .wrap {
+        display: flex;
+
+        :global(.text-input) {
+          flex: 1;
+        }
+      }
 
       .search-results {
         position: absolute;
@@ -315,11 +330,17 @@
       gap: 1em;
 
       :global(.publish-date-field) {
+        display: flex;
         flex: 1;
       }
 
       :global(.lineage-source-field) {
         flex: 3;
+        display: flex;
+
+        :global(.text-input) {
+          flex: 1;
+        }
       }
     }
 

--- a/src/lib/components/Form/Field/37_QualityReportCheckField.svelte
+++ b/src/lib/components/Form/Field/37_QualityReportCheckField.svelte
@@ -54,7 +54,7 @@
         <Switch bind:checked={value} onSMUISwitchChange={onCheckChange} />
       </FormField>
     </fieldset>
-    <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/Field/39_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/39_AdditionalInformation.svelte
@@ -101,7 +101,7 @@
       </IconButton>
     </legend>
     <FieldHint {fieldConfig} />
-    {#each contentDescriptions as contentDescription (contentDescription.listId)}
+    {#each contentDescriptions as contentDescription, index (contentDescription.listId)}
       <fieldset class="contentDescription">
         <legend>
           <IconButton
@@ -113,46 +113,65 @@
             delete
           </IconButton>
         </legend>
-        <TextInput
-          bind:value={contentDescription.description}
-          label="Titel"
-          onblur={persistContentDescriptions}
-          fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.title')}
-          validationResult={getFieldConfig(39, 'isoMetadata.contentDescriptions.title')?.validator(
-            contentDescription.description
-          )}
-        />
-        <div class="inline-fields">
-          <SelectInput
-            value={contentDescription.code}
-            onChange={(code) => {
-              contentDescription.code = code as CI_OnLineFunctionCode;
-              persistContentDescriptions();
-            }}
-            class="code-select-field"
-            label="Code"
-            fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.code')}
-            validationResult={getFieldConfig(39, 'isoMetadata.contentDescriptions.code')?.validator(
-              contentDescription.code
-            )}
-            options={[
-              { label: 'Herunterladen', key: 'download' },
-              { label: 'Information', key: 'information' },
-              { label: 'Offline-Zugriff', key: 'offlineAccess' },
-              { label: 'Bestellung', key: 'order' },
-              { label: 'Suche', key: 'search' }
-            ]}
-          />
+        <div class="subfield-wrapper">
           <TextInput
-            bind:value={contentDescription.url}
-            class="url-field"
-            label="Url"
+            bind:value={contentDescription.description}
+            label="Titel"
             onblur={persistContentDescriptions}
-            fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.url')}
-            validationResult={getFieldConfig(39, 'isoMetadata.contentDescriptions.url')?.validator(
-              contentDescription.url
-            )}
+            fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.title')}
+            validationResult={getFieldConfig(
+              39,
+              'isoMetadata.contentDescriptions.title'
+            )?.validator(contentDescription.description)}
           />
+          <FieldTools
+            key={`${KEY}[${index}].description`}
+            fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.description.title')}
+          />
+        </div>
+        <div class="inline-fields">
+          <div class="subfield-wrapper code-select-field">
+            <SelectInput
+              value={contentDescription.code}
+              onChange={(code) => {
+                contentDescription.code = code as CI_OnLineFunctionCode;
+                persistContentDescriptions();
+              }}
+              label="Code"
+              fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.code')}
+              validationResult={getFieldConfig(
+                39,
+                'isoMetadata.contentDescriptions.code'
+              )?.validator(contentDescription.code)}
+              options={[
+                { label: 'Herunterladen', key: 'download' },
+                { label: 'Information', key: 'information' },
+                { label: 'Offline-Zugriff', key: 'offlineAccess' },
+                { label: 'Bestellung', key: 'order' },
+                { label: 'Suche', key: 'search' }
+              ]}
+            />
+            <FieldTools
+              key={`${KEY}[${index}].code`}
+              fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.code')}
+            />
+          </div>
+          <div class="subfield-wrapper url-field">
+            <TextInput
+              bind:value={contentDescription.url}
+              label="Url"
+              onblur={persistContentDescriptions}
+              fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.url')}
+              validationResult={getFieldConfig(
+                39,
+                'isoMetadata.contentDescriptions.url'
+              )?.validator(contentDescription.url)}
+            />
+            <FieldTools
+              key={`${KEY}[${index}].url`}
+              fieldConfig={getFieldConfig(39, 'isoMetadata.contentDescriptions.url')}
+            />
+          </div>
         </div>
       </fieldset>
     {/each}
@@ -181,6 +200,14 @@
       display: flex;
       flex-direction: column;
       gap: 1em;
+
+      .subfield-wrapper {
+        display: flex;
+
+        :global(.text-input) {
+          flex: 1;
+        }
+      }
 
       legend {
         text-align: right;

--- a/src/lib/components/Form/FieldTools.svelte
+++ b/src/lib/components/Form/FieldTools.svelte
@@ -9,11 +9,13 @@
   import { toast } from 'svelte-french-toast';
   import { popconfirm } from '../../context/PopConfirmContex.svelte';
   import type { FieldKey } from '$lib/models/form';
+  import type { FullFieldConfig } from './FieldsConfig';
 
   export type FieldToolsProps = {
     key: FieldKey;
     children?: Snippet;
     checkMarkAnmiationRunning?: boolean;
+    fieldConfig?: FullFieldConfig;
     noCheckmark?: boolean;
     noHelpButton?: boolean;
     noCopyButton?: boolean;
@@ -23,6 +25,7 @@
     key,
     children,
     checkMarkAnmiationRunning: running = $bindable<boolean>(false),
+    fieldConfig,
     noCheckmark = false,
     noHelpButton = false,
     noCopyButton = false
@@ -85,7 +88,7 @@
     <Icon class="material-icons" title="Fehler beim Prüfen der Hilfe.">warning</Icon>
   {/await}
   {#if !noCopyButton}
-    <CopyButton {key} />
+    <CopyButton {key} {fieldConfig} />
   {/if}
   {#if metadata?.clonedFromId}
     {#await getValueFromOriginal()}

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -8,6 +8,7 @@ import {
   type IsoTheme,
   type Keywords,
   type Layer,
+  type MaintenanceFrequency,
   type MetadataProfile,
   type Service,
   type TermsOfUse
@@ -360,6 +361,23 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
         };
       }
       return { valid: true };
+    },
+    getCopyValue: async (val?: MaintenanceFrequency) => {
+      const maintenanceFrequencyLabels: Record<MaintenanceFrequency, string> = {
+        continual: 'kontinuierlich',
+        daily: 'täglich',
+        weekly: 'wöchentlich',
+        fortnightly: 'vierzehntägig',
+        monthly: 'monatlich',
+        quarterly: 'vierteljährlich',
+        biannually: 'halbjährlich',
+        annually: 'jährlich',
+        asNeeded: 'bei Bedarf',
+        irregular: 'unregelmäßig',
+        notPlanned: 'nicht geplant',
+        unknown: 'unbekannt'
+      };
+      return val ? maintenanceFrequencyLabels[val] : '';
     },
     section: 'temp_and_spatial',
     required: true

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -858,6 +858,16 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     key: 'isoMetadata.contentDescriptions.code',
     collectionKey: 'isoMetadata.contentDescriptions',
     validator: optionalValidator,
+    getCopyValue: (val?: string) => {
+      const codeLabels: Record<string, string> = {
+        download: 'Herunterladen',
+        information: 'Information',
+        offlineAccess: 'Offline-Zugriff',
+        order: 'Bestellung',
+        search: 'Suche'
+      };
+      return val ? codeLabels[val] || '' : '';
+    },
     section: 'additional',
     required: false
   },

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -723,6 +723,9 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     label: 'Überprüfung des Qualitätsberichts',
     key: 'isoMetadata.valid',
     validator: () => ({ valid: true }),
+    getCopyValue: (val?: boolean) => {
+      return val ? 'Überprüft' : 'Nicht überprüft';
+    },
     section: 'classification',
     required: false
   },

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -767,6 +767,12 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     key: 'isoMetadata.lineage.date',
     collectionKey: 'isoMetadata.lineage',
     validator: optionalValidator,
+    getCopyValue: (val?: string) => {
+      if (!isDefined(val)) {
+        return '';
+      }
+      return formatDate(val);
+    },
     section: 'additional',
     required: false
   },

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -8,7 +8,8 @@ import {
   type Keywords,
   type Layer,
   type MetadataProfile,
-  type Service
+  type Service,
+  type TermsOfUse
 } from '$lib/models/metadata';
 import { getValue, type Section } from '$lib/context/FormContext.svelte';
 import type { Role } from '$lib/models/keycloak';
@@ -113,6 +114,11 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
         };
       }
       return { valid: true };
+    },
+    getCopyValue: async (val: string) => {
+      const response = await fetch('/data/privacy');
+      const privacyOptions: Option[] = await response.json();
+      return privacyOptions.find(option => option.key === val)?.label || '';
     },
     section: 'classification',
     required: true
@@ -542,6 +548,11 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
         };
       }
       return { valid: true };
+    },
+    getCopyValue: async (val: number) => {
+      const response = await fetch('/data/terms_of_use');
+      const termsOfUseList: TermsOfUse[] = await response.json();
+      return termsOfUseList.find(tou => tou.id === val)?.shortname || '';
     },
     section: 'classification',
     required: true,

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -5,6 +5,7 @@ import {
   type Contacts,
   type DownloadInfo,
   type FeatureType,
+  type IsoTheme,
   type Keywords,
   type Layer,
   type MetadataProfile,
@@ -290,6 +291,12 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
         };
       }
       return { valid: true };
+    },
+    getCopyValue: async (val?: string[]) => {
+      const response = await fetch('/data/iso_themes');
+      const isoThemes: IsoTheme[] = await response.json();
+      const categories = val?.map((v) => isoThemes.find(category => category.isoID === v)?.isoName) || [];
+      return categories.join(', ');
     },
     section: 'classification',
     required: true,

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { FieldKey } from '$lib/models/form';
+import type { FieldKey, Option } from '$lib/models/form';
 import {
   type ColumnInfo,
   type Contacts,
@@ -27,7 +27,7 @@ export interface YamlFieldConfig {
   hint?: string;
 }
 
-export interface FullFieldConfig<T> extends YamlFieldConfig {
+export interface FullFieldConfig<T = any> extends YamlFieldConfig {
   // the key in the json structure
   key: FieldKey;
   // if the field is required
@@ -307,6 +307,12 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       }
       return { valid: true };
     },
+    getCopyValue: (val?: Keywords) => {
+      if (!val || !val.default || val.default.length < 1) {
+        return '';
+      }
+      return val.default.map((kw) => kw.keyword).join(', ');
+    },
     section: 'basedata',
     required: true,
     editingRoles: ['MdeEditor']
@@ -316,7 +322,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     label: 'geliefertes Koordinatensystem',
     key: 'technicalMetadata.deliveredCrs',
     placeholder: 'EPSG:25833',
-    validator: (val: any) => {
+    validator: (val?: string) => {
       if (!isDefined(val)) {
         return {
           valid: false,

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -130,6 +130,17 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       }
       return { valid: true };
     },
+    getCopyValue(val?: MetadataProfile) {
+      if (!val) {
+        return '';
+      }
+      const valueMap = {
+        ISO: 'ISO',
+        INSPIRE_HARMONISED: 'INSPIRE harmonisiert',
+        INSPIRE_IDENTIFIED: 'INSPIRE identifiziert'
+      };
+      return valueMap[val];
+    },
     section: 'classification',
     required: true
   },

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -70,6 +70,18 @@ const optionalValidator = () => ({
   valid: true
 });
 
+const formatDate = (date: Date | string): string => {
+  if (typeof date === 'string') {
+    date = new Date(date);
+  }
+  const format = Intl.DateTimeFormat('de-DE', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+  return format.format(date);
+}
+
 export const FieldConfigs: FullFieldConfig<any>[] = [
   {
     profileId: 1,
@@ -216,6 +228,12 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     label: 'Erstellungsdatum',
     key: 'isoMetadata.created',
     validator: optionalValidator,
+    getCopyValue: (val?: string) => {
+      if (!isDefined(val)) {
+        return '';
+      }
+      return formatDate(val);
+    },
     section: 'temp_and_spatial',
     required: false
   },
@@ -232,6 +250,12 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       }
       return { valid: true };
     },
+    getCopyValue: (val?: string) => {
+      if (!isDefined(val)) {
+        return '';
+      }
+      return formatDate(val);
+    },
     section: 'temp_and_spatial',
     required: true
   },
@@ -240,6 +264,12 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     label: 'letzte Aktualisierung',
     key: 'isoMetadata.modified',
     validator: optionalValidator,
+    getCopyValue: (val?: string) => {
+      if (!isDefined(val)) {
+        return '';
+      }
+      return formatDate(val);
+    },
     section: 'temp_and_spatial',
     required: true
   },
@@ -257,6 +287,22 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
         };
       }
       return { valid: true };
+    },
+    getCopyValue: (val?: string) => {
+      const validTo = getValue<string>('isoMetadata.validTo');
+      const fromDate = val && formatDate(val);
+      const toDate = validTo && formatDate(validTo);
+
+      if (fromDate && toDate) {
+        return `Vom ${fromDate} bis ${toDate}`;
+      }
+      if (fromDate) {
+        return `Ab ${fromDate}`;
+      }
+      if (toDate) {
+        return `Bis ${toDate}`;
+      }
+      return '';
     },
     section: 'temp_and_spatial',
     required: false

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -44,6 +44,8 @@ export interface FullFieldConfig<T> extends YamlFieldConfig {
   validator: (val: T | undefined, extra?: Record<string, any>) => ValidationResult;
   // additional parameters for the validator function
   validatorExtraParams?: Array<FieldKey | 'PARENT_VALUE'>;
+  // this function is used to get the value for the copy button
+  getCopyValue?: (val: T | undefined) => string | Promise<string>;
 }
 
 const isDefined = <T>(val: T): val is NonNullable<T> => {

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -154,7 +154,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     label: 'INSPIRE Annex Thema',
     key: 'isoMetadata.inspireTheme',
     validatorExtraParams: ['isoMetadata.metadataProfile'],
-    validator: (val: any, extraParams) => {
+    validator: (val: string[], extraParams) => {
       const metadataProfile = extraParams?.['isoMetadata.metadataProfile'];
       if (metadataProfile === 'ISO') {
         return { valid: true };
@@ -166,6 +166,12 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
         };
       }
       return { valid: true };
+    },
+    getCopyValue: async (val?: string[]) => {
+      const response = await fetch('/data/inspire_themes');
+      const themesArray: Option[] = await response.json();
+      const themes = val?.map((v) => themesArray.find(theme => theme.key === v)?.label) || [];
+      return themes.join(', ');
     },
     section: 'classification',
     required: true

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -673,6 +673,9 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       }
       return { valid: true };
     },
+    getCopyValue: (val?: [number]) => {
+      return val?.length === 1 ? val[0].toString() : '';
+    },
     section: 'temp_and_spatial',
     required: true
   },

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -16,7 +16,7 @@
   import F15_KeywordsField from './Field/15_KeywordsField.svelte';
   import F29_PreviewField from './Field/29_PreviewField.svelte';
   import F19_ContactsField from './Field/19_ContactsField.svelte';
-  import F05_InspireType from './Field/05_InspireType.svelte';
+  import F05_MetadataProfileField from './Field/05_MetadataProfileField.svelte';
   import F04_PrivacyField from './Field/04_PrivacyField.svelte';
   import F25_TermsOfUseField from './Field/25_TermsOfUseField.svelte';
   import F26_TermsOfUseSourceField from './Field/26_TermsOfUseSourceField.svelte';
@@ -179,7 +179,7 @@
         <section id="classification" transition:fade>
           <fieldset class="inspire-fieldset">
             <legend>INSPIRE Relevanz</legend>
-            <F05_InspireType />
+            <F05_MetadataProfileField />
             <F07_AnnexThemeField />
             <F38_InspireAnnexVersionField />
           </fieldset>

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -42,7 +42,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -51,7 +51,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
     {#if metadataPreview}
       <AutoFillButton title="Wert aus Vorlage übernehmen" onclick={getAutoFillValues} />
     {/if}

--- a/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
@@ -65,7 +65,7 @@
       </div>
     </div>
   </fieldset>
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/49_LayerTitle.svelte
+++ b/src/lib/components/Form/service/Field/49_LayerTitle.svelte
@@ -31,7 +31,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/50_LayerName.svelte
+++ b/src/lib/components/Form/service/Field/50_LayerName.svelte
@@ -41,7 +41,7 @@
       {validationResult}
       onchange={onChangeInternal}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
+++ b/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
@@ -42,7 +42,7 @@
       {validationResult}
       onchange={onChangeInternal}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
+++ b/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
@@ -44,7 +44,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
@@ -31,7 +31,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/54_LayerDescription.svelte
+++ b/src/lib/components/Form/service/Field/54_LayerDescription.svelte
@@ -32,7 +32,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
+++ b/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
@@ -31,7 +31,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/56_LayerSecondaryDatasource.svelte
+++ b/src/lib/components/Form/service/Field/56_LayerSecondaryDatasource.svelte
@@ -38,7 +38,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/58_ServiceType.svelte
+++ b/src/lib/components/Form/service/Field/58_ServiceType.svelte
@@ -47,7 +47,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -47,7 +47,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
     {#if metadataTitle}
       <AutoFillButton title="Wert aus Vorlage übernehmen" onclick={getAutoFillValues} />
     {/if}

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -47,7 +47,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
     {#if metadataDescription}
       <AutoFillButton title="Wert aus Vorlage übernehmen" onclick={getAutoFillValues} />
     {/if}

--- a/src/lib/components/Form/service/Field/62_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeTitle.svelte
@@ -30,7 +30,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/63_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/63_FeatureTypeName.svelte
@@ -37,7 +37,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/65_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeName.svelte
@@ -30,7 +30,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/66_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeAlias.svelte
@@ -30,7 +30,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/67_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/67_AttributeDatatype.svelte
@@ -52,7 +52,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/68_AttributeFilterType.svelte
+++ b/src/lib/components/Form/service/Field/68_AttributeFilterType.svelte
@@ -46,7 +46,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/69_DownloadTitle.svelte
+++ b/src/lib/components/Form/service/Field/69_DownloadTitle.svelte
@@ -30,7 +30,7 @@
       }
     }}
   />
-  <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/70_DownloadFiletype.svelte
+++ b/src/lib/components/Form/service/Field/70_DownloadFiletype.svelte
@@ -37,7 +37,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/71_DownloadHref.svelte
+++ b/src/lib/components/Form/service/Field/71_DownloadHref.svelte
@@ -37,7 +37,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/72_DownloadFilesize.svelte
+++ b/src/lib/components/Form/service/Field/72_DownloadFilesize.svelte
@@ -37,7 +37,7 @@
         }
       }}
     />
-    <FieldTools key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 


### PR DESCRIPTION
Introduce a `getCopyValue` function for multiple fields and enhance the copy functionality for the annex theme and keywords. Temporarily remove the copy button from all service fields until they function as expected.