### PR TITLE
Remove unused searchForMetadata method

### DIFF
--- a/src/lib/api/metadata.ts
+++ b/src/lib/api/metadata.ts
@@ -46,40 +46,6 @@ export const getMetadataCollectionByMetadataId = async (
   return await response.json();
 };
 
-export const searchForMetadata = async (
-  token: string,
-  searchTerm: string,
-  pagingOpts = defaultPage
-): Promise<MetadataCollection[]> => {
-  if (!token) {
-    log.error('No token provided.');
-    return Promise.reject(new Error('No token provided.'));
-  }
-
-  const url: URL = new URL(`${env.BACKEND_URL}/metadata/search`);
-  url.searchParams.append('searchTerm', searchTerm);
-
-  if (pagingOpts) {
-    const offset = pagingOpts.page * pagingOpts.size;
-    const limit = pagingOpts.size;
-    url.searchParams.append('offset', offset.toString());
-    url.searchParams.append('limit', limit.toString());
-  }
-
-  const response = await fetch(url, {
-    headers: new Headers({
-      Authorization: `Bearer ${token}`,
-      accept: 'application/json'
-    })
-  });
-
-  if (!response.ok) {
-    throw new Error(`HTTP error status: ${response.status}`);
-  }
-  const data = await response.json();
-  return data;
-};
-
 export const queryMetadata = async (
   token: string,
   queryConfig: QueryConfig,


### PR DESCRIPTION
Eliminate the unused `searchForMetadata` method to clean up the codebase.