### PR TITLE
Override the (non-configurable) default idle timeout of 10 seconds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY .env.example .env
 COPY package.json bun.lock ./
 
+# Unfortunately the svelte-adapter-bun does't allow to set the idle timeout.
+RUN sed -i "s/serverOptions = {/serverOptions = {\n  idleTimeout: 255,/g" ./build/index.js
+
 EXPOSE 3000
 
 ENTRYPOINT ["bun", "run", "start"]


### PR DESCRIPTION
In the production build a [bun server](https://bun.sh/docs/api/http#bun-serve) including a specialized configuration is used to serve the client (whereas in the development mode a vite dev server is used).

Unfortunately the [idletimeout](https://bun.sh/docs/api/http#idletimeout) is not configurable in the [svelte-adapter-bun](https://github.com/gornostay25/svelte-adapter-bun) and the default of 10 seconds might cause errors in scenarios where e.g. proxied interface is taking more than this to actually fulfil.

Please note @KaiVolland @hwbllmnn 