### PR TITLE
Allow float values for resolution input

### DIFF
--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -88,6 +88,7 @@
         fieldConfig={resolutionFieldConfig}
         onblur={onBlur}
         validationResult={resolutionValidationResult}
+        step="any"
       />
     {/if}
     {#if selected === SCALE_KEY}


### PR DESCRIPTION
Adjust the resolution input field to accept float values by setting the step attribute to "any".