### PR TITLE
Fix scroll timing issue for comments section

### DIFF
--- a/src/lib/components/Form/CommentsPanel.svelte
+++ b/src/lib/components/Form/CommentsPanel.svelte
@@ -89,7 +89,8 @@
     return comment.userId === myUserId && index === comments.length - 1 && notOlderThenTenMinutes;
   }
 
-  function scrollToBottom() {
+  async function scrollToBottom() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const commentsList = document.querySelector('.comments');
     if (commentsList) {
       commentsList.scrollTop = commentsList.scrollHeight;


### PR DESCRIPTION
Introduce a delay in the scroll function to ensure the correct height is calculated before scrolling to the bottom of the comments section.