### PR TITLE
Move QualityReportCheckField to Inspire fieldset

### DIFF
--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -182,11 +182,11 @@
             <F05_MetadataProfileField />
             <F07_AnnexThemeField />
             <F38_InspireAnnexVersionField />
+            <F37_QualityReportCheckField />
           </fieldset>
           <F04_PrivacyField />
           <F25_TermsOfUseField />
           <F26_TermsOfUseSourceField />
-          <F37_QualityReportCheckField />
           <F06_HighValueDatasetField />
           <F13_TopicCategory />
           <ScrollToTopButton target={formWrapper} />


### PR DESCRIPTION
Relocate the QualityReportCheckField to the Inspire fieldset for better organization.