### PR TITLE
Update text-wrap for Breadcrumbs

### DIFF
--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -51,7 +51,7 @@
     li {
       max-height: 1em;
       overflow: clip;
-      text-wrap: inherit;
+      text-wrap: nowrap;
     }
 
     i {


### PR DESCRIPTION
Change the text-wrap property to nowrap for better display of Breadcrumbs.