### PR TITLE
Introduce Inspire Format Name field

### DIFF
--- a/src/lib/components/Form/Field/07_AnnexThemeField.svelte
+++ b/src/lib/components/Form/Field/07_AnnexThemeField.svelte
@@ -8,16 +8,17 @@
   } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import SelectInput from '../Inputs/SelectInput.svelte';
-  import type { Option } from '$lib/models/form';
   import type { FullFieldConfig } from '../FieldsConfig';
   import { getContext } from 'svelte';
   import type { IsoTheme, MetadataProfile } from '$lib/models/metadata';
   import MultiSelectInput from '../Inputs/MultiSelectInput.svelte';
   import { toast } from 'svelte-french-toast';
+  import type { InspireThemeConfig } from '$lib/models/inspire';
 
   const PROFILE_KEY = 'isoMetadata.metadataProfile';
   const KEY = 'isoMetadata.inspireTheme';
   const TOPIC_KEY = 'isoMetadata.topicCategory';
+  const FORMAT_KEY = 'isoMetadata.inspireFormatName';
 
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formState.metadata);
@@ -40,6 +41,9 @@
       showCheckmark = true;
     }
     await updateTopicCategory(newValue);
+
+    // reset format name
+    await persistValue(FORMAT_KEY, null);
   };
 
   const updateTopicCategory = async (inspireIDs?: string[]) => {
@@ -71,7 +75,7 @@
       return [];
     }
 
-    const data: Option[] = await response.json();
+    const data: InspireThemeConfig[] = await response.json();
     return data;
   };
 </script>

--- a/src/lib/components/Form/Field/70_InspireFormatName.svelte
+++ b/src/lib/components/Form/Field/70_InspireFormatName.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import {
+    FORMSTATE_CONTEXT,
+    getFieldConfig,
+    getValue,
+    persistValue,
+    type FormState
+  } from '$lib/context/FormContext.svelte';
+  import FieldTools from '../FieldTools.svelte';
+  import SelectInput from '../Inputs/SelectInput.svelte';
+  import type { Option } from '$lib/models/form';
+  import type { FullFieldConfig } from '../FieldsConfig';
+  import { getContext } from 'svelte';
+  import type { MetadataProfile } from '$lib/models/metadata';
+  import type { InspireThemeConfig } from '$lib/models/inspire';
+  import { toast } from 'svelte-french-toast';
+
+  const PROFILE_KEY = 'isoMetadata.metadataProfile';
+  const KEY = 'isoMetadata.inspireFormatName';
+  const ANNEX_THEME_KEY = 'isoMetadata.inspireTheme';
+
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
+  const annexValue = $derived(getValue<string[]>(ANNEX_THEME_KEY));
+  const metadata = $derived(formState.metadata);
+
+  let metadataProfile = $derived(getValue<MetadataProfile>(PROFILE_KEY, metadata));
+
+  const valueFromData = $derived(getValue<string>(KEY));
+  let value = $state<string>();
+  $effect(() => {
+    value = valueFromData;
+  });
+
+  let showCheckmark = $state(false);
+  const fieldConfig = getFieldConfig<string>(70);
+  let validationResult = $derived(fieldConfig?.validator(value));
+  let options: Option[] = $state([]);
+
+  const onChange = async (newValue?: string) => {
+    const response = await persistValue(KEY, newValue);
+    if (response.ok) {
+      showCheckmark = true;
+    }
+  };
+
+  $effect(() => {
+    fetchOptions(annexValue);
+  });
+
+  const fetchOptions = async (annexValue?: string[]) => {
+    if (!annexValue || annexValue.length === 0) {
+      options = [];
+      return;
+    }
+
+    const response = await fetch('/data/inspire_themes');
+
+    if (!response.ok) {
+      toast.error('Fehler beim Abrufen der Inspire Format Namen');
+      return [];
+    }
+
+    const data = await response.json();
+    const theme = data.find((theme: InspireThemeConfig) => theme.key === annexValue[0]);
+    const formatNames = theme?.schemaNames || [];
+    options = formatNames.map((name: string) => ({ label: name, key: name }));
+  };
+</script>
+
+{#if metadataProfile === 'INSPIRE_HARMONISED' && options.length > 0}
+  <div class="inspire-format-name-field">
+    <SelectInput
+      label={fieldConfig?.label}
+      fieldConfig={fieldConfig as unknown as FullFieldConfig<string>}
+      {options}
+      {value}
+      {onChange}
+      {validationResult}
+    />
+    <FieldTools {fieldConfig} key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  </div>
+{/if}
+
+<style lang="scss">
+  .inspire-format-name-field {
+    position: relative;
+    display: flex;
+    gap: 0.25em;
+
+    :global(.select-input),
+    :global(.multi-select-input) {
+      flex: 1;
+    }
+  }
+</style>

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -1274,8 +1274,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
   },
   {
     profileId: 70,
-    key: 'isoMetadata.services.featureTypes.inspireFormatName',
-    collectionKey: 'isoMetadata.services.featureTypes',
+    key: 'isoMetadata.inspireFormatName',
     validatorExtraParams: ['isoMetadata.metadataProfile'],
     validator: (val: string[], extraParams) => {
       const metadataProfile = extraParams?.['isoMetadata.metadataProfile'];

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -1271,5 +1271,26 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     },
     section: 'services',
     required: true
+  },
+  {
+    profileId: 70,
+    key: 'isoMetadata.services.featureTypes.inspireFormatName',
+    collectionKey: 'isoMetadata.services.featureTypes',
+    validatorExtraParams: ['isoMetadata.metadataProfile'],
+    validator: (val: string[], extraParams) => {
+      const metadataProfile = extraParams?.['isoMetadata.metadataProfile'];
+      if (metadataProfile === 'ISO') {
+        return { valid: true };
+      }
+      if (!isDefined(val)) {
+        return {
+          valid: false,
+          helpText: 'Bitte geben Sie einen INSPIRE Format Namen an.'
+        };
+      }
+      return { valid: true };
+    },
+    section: 'services',
+    required: true
   }
 ];

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -38,6 +38,7 @@
   import F32_Lineage from './Field/32_Lineage.svelte';
   import F39_AdditionalInformation from './Field/39_AdditionalInformation.svelte';
   import F38_InspireAnnexVersionField from './Field/38_InspireAnnexVersionField.svelte';
+  import F70_InspireFormatNameField from './Field/70_InspireFormatName.svelte';
   import ServicesSection from './service/ServicesSection.svelte';
   import FormFooter from './FormFooter.svelte';
   import type { MetadataCollection } from '$lib/models/metadata';
@@ -180,6 +181,7 @@
             <legend>Angaben zu INSPIRE</legend>
             <F05_MetadataProfileField />
             <F07_AnnexThemeField />
+            <F70_InspireFormatNameField />
             <F38_InspireAnnexVersionField />
             <F37_QualityReportCheckField />
           </fieldset>

--- a/src/lib/models/inspire.ts
+++ b/src/lib/models/inspire.ts
@@ -1,3 +1,9 @@
+export type InspireThemeConfig = {
+  key: string;
+  label: string;
+  schemaNames: string[];
+};
+
 export type InspireRegister = {
   register: {
     registry: {

--- a/src/routes/data/inspire_format_names/+server.ts
+++ b/src/routes/data/inspire_format_names/+server.ts
@@ -1,0 +1,15 @@
+import { error, json } from '@sveltejs/kit';
+import { getAccessToken } from '$lib/auth/cookies.js';
+import { parse } from 'yaml';
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ cookies }) {
+  const token = await getAccessToken(cookies);
+  if (!token) return error(401, 'Unauthorized');
+
+  const file = Bun.file('/data/codelists/inspire_format_names.yaml');
+  const themes = await file.text();
+  const parsed = parse(themes);
+
+  return json(parsed);
+}

--- a/tests/fixtures/metadata1.ts
+++ b/tests/fixtures/metadata1.ts
@@ -100,6 +100,7 @@ export default {
       ]
     },
     inspireTheme: ['AC'],
+    inspireFormatName: '0185 GML Application Schema',
     inspireAnnexVersion: '0815',
     thesauri: {},
     highValueDataset: false,

--- a/tests/fixtures/metadata2.ts
+++ b/tests/fixtures/metadata2.ts
@@ -30,6 +30,7 @@ export default {
       ]
     },
     inspireTheme: ['AC'],
+    inspireFormatName: '0185 GML Application Schema',
     inspireAnnexVersion: '0815',
     thesauri: {},
     highValueDataset: false,

--- a/tests/fixtures/metadata_all_valid_but_buggy_layers.ts
+++ b/tests/fixtures/metadata_all_valid_but_buggy_layers.ts
@@ -64,6 +64,7 @@ export default {
   isoMetadata: {
     metadataProfile: 'INSPIRE_HARMONISED',
     inspireTheme: ['AD'],
+    inspireFormatName: 'Addresses GML Application Schema',
     inspireAnnexVersion: 'version 4.0',
     distributionVersions: [
       {


### PR DESCRIPTION
Add a new field for selecting INSPIRE format names, including validation and fetching options based on the selected annex theme. This change enhances the form's capability to handle INSPIRE metadata.

:warning: relies on https://github.com/gdi-be/mde-deployment/pull/48