### PR TITLE
Add copy functionality to service inputs and HVD retrieval

### DIFF
--- a/src/lib/components/Form/CopyButton.svelte
+++ b/src/lib/components/Form/CopyButton.svelte
@@ -7,13 +7,14 @@
   import toast from 'svelte-french-toast';
 
   export type CopyButtonProps = {
+    value?: unknown;
     key: FieldKey;
     fieldConfig?: FullFieldConfig;
   };
 
-  let { key, fieldConfig }: CopyButtonProps = $props();
+  let { key, fieldConfig, value: valueFromProps }: CopyButtonProps = $props();
 
-  const value = $derived(getValue(key));
+  const value = $derived(valueFromProps ?? getValue(key));
   let copied = $state(false);
   let copyFailed = $state(false);
 
@@ -28,7 +29,7 @@
           toast.error('Fehler beim Abrufen des Wertes für die Zwischenablage.');
           return;
         }
-      } else if (value) {
+      } else if (value != null && value !== undefined) {
         if (typeof value === 'string') {
           text = value;
         } else if (typeof value === 'number') {

--- a/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
+++ b/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
@@ -81,7 +81,11 @@
       {/await}
     {/if}
   </fieldset>
-  <FieldTools key={CATEGORY_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools
+    fieldConfig={categoryFieldConfig}
+    key={CATEGORY_KEY}
+    bind:checkMarkAnmiationRunning={showCheckmark}
+  />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/Field/39_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/39_AdditionalInformation.svelte
@@ -176,7 +176,7 @@
       </fieldset>
     {/each}
   </fieldset>
-  <FieldTools key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools noCopyButton key={KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/FieldTools.svelte
+++ b/src/lib/components/Form/FieldTools.svelte
@@ -12,6 +12,7 @@
   import type { FullFieldConfig } from './FieldsConfig';
 
   export type FieldToolsProps = {
+    value?: unknown;
     key: FieldKey;
     children?: Snippet;
     checkMarkAnmiationRunning?: boolean;
@@ -28,7 +29,8 @@
     fieldConfig,
     noCheckmark = false,
     noHelpButton = false,
-    noCopyButton = false
+    noCopyButton = false,
+    value
   }: FieldToolsProps = $props();
 
   const metadata = $derived(getFormContext()?.metadata);
@@ -88,7 +90,7 @@
     <Icon class="material-icons" title="Fehler beim Prüfen der Hilfe.">warning</Icon>
   {/await}
   {#if !noCopyButton}
-    <CopyButton {key} {fieldConfig} />
+    <CopyButton {value} {key} {fieldConfig} />
   {/if}
   {#if metadata?.clonedFromId}
     {#await getValueFromOriginal()}

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -215,6 +215,12 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       }
       return { valid: true };
     },
+    getCopyValue: async (val?: string[]) => {
+      const response = await fetch('/data/hvd_categories');
+      const categories: Option[] = await response.json();
+      const machtingCategories = val?.map((v) => categories.find((theme) => theme.key === v)?.label) || [];
+      return machtingCategories.join(', ');
+    },
     section: 'classification',
     required: true
   },

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -42,7 +42,7 @@
         }
       }}
     />
-    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -51,7 +51,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
     {#if metadataPreview}
       <AutoFillButton title="Wert aus Vorlage übernehmen" onclick={getAutoFillValues} />
     {/if}

--- a/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
@@ -36,32 +36,44 @@
     <FieldHint {fieldConfig} {validationResult} />
     <div class="inputs">
       <div class="legend-text-fields">
-        <TextInput
-          label="Url"
-          value={value?.url}
-          onchange={(e: Event) => update('url', (e.target as HTMLInputElement).value)}
-          fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.url')}
-        />
-        <TextInput
-          label="Format"
-          value={value?.format}
-          onchange={(e: Event) => update('format', (e.target as HTMLInputElement).value)}
-          fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.format')}
-        />
+        <div class="field-wrapper">
+          <TextInput
+            label="Url"
+            value={value?.url}
+            onchange={(e: Event) => update('url', (e.target as HTMLInputElement).value)}
+            fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.url')}
+          />
+          <FieldTools value={value?.url} key={KEY} noCheckmark noHelpButton />
+        </div>
+        <div class="field-wrapper">
+          <TextInput
+            label="Format"
+            value={value?.format}
+            onchange={(e: Event) => update('format', (e.target as HTMLInputElement).value)}
+            fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.format')}
+          />
+          <FieldTools value={value?.format} key={KEY} noCheckmark noHelpButton />
+        </div>
       </div>
       <div class="legend-size-fields">
-        <NumberInput
-          label="Breite"
-          value={value?.width}
-          onchange={(e: Event) => update('width', (e.target as HTMLInputElement).value)}
-          fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.width')}
-        />
-        <NumberInput
-          label="Höhe"
-          value={value?.height}
-          onchange={(e: Event) => update('height', (e.target as HTMLInputElement).value)}
-          fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.height')}
-        />
+        <div class="field-wrapper">
+          <NumberInput
+            label="Breite"
+            value={value?.width}
+            onchange={(e: Event) => update('width', (e.target as HTMLInputElement).value)}
+            fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.width')}
+          />
+          <FieldTools value={value?.width} key={KEY} noCheckmark noHelpButton />
+        </div>
+        <div class="field-wrapper">
+          <NumberInput
+            label="Höhe"
+            value={value?.height}
+            onchange={(e: Event) => update('height', (e.target as HTMLInputElement).value)}
+            fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.height')}
+          />
+          <FieldTools value={value?.height} key={KEY} noCheckmark noHelpButton />
+        </div>
       </div>
     </div>
   </fieldset>
@@ -87,6 +99,11 @@
         flex-wrap: wrap;
         gap: 1em;
 
+        div.field-wrapper {
+          display: flex;
+          gap: 0.25em;
+        }
+
         div.legend-text-fields {
           flex: 1;
         }
@@ -100,6 +117,7 @@
 
         :global(.text-input),
         :global(.number-input) {
+          flex: 1;
           border: none;
           background-color: rgba(244, 244, 244, 0.7);
         }

--- a/src/lib/components/Form/service/Field/49_LayerTitle.svelte
+++ b/src/lib/components/Form/service/Field/49_LayerTitle.svelte
@@ -31,7 +31,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/50_LayerName.svelte
+++ b/src/lib/components/Form/service/Field/50_LayerName.svelte
@@ -41,7 +41,7 @@
       {validationResult}
       onchange={onChangeInternal}
     />
-    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
+++ b/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
@@ -42,7 +42,7 @@
       {validationResult}
       onchange={onChangeInternal}
     />
-    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
+++ b/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
@@ -44,7 +44,7 @@
         }
       }}
     />
-    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
@@ -31,7 +31,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/54_LayerDescription.svelte
+++ b/src/lib/components/Form/service/Field/54_LayerDescription.svelte
@@ -32,7 +32,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
+++ b/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
@@ -31,7 +31,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/56_LayerSecondaryDatasource.svelte
+++ b/src/lib/components/Form/service/Field/56_LayerSecondaryDatasource.svelte
@@ -38,7 +38,7 @@
         }
       }}
     />
-    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/58_ServiceType.svelte
+++ b/src/lib/components/Form/service/Field/58_ServiceType.svelte
@@ -14,6 +14,7 @@
   const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
   const HELP_KEY = 'isoMetadata.services.type';
+  console.log(value);
 </script>
 
 <div class="service-type-field">
@@ -47,7 +48,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} {fieldConfig} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -47,7 +47,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
     {#if metadataTitle}
       <AutoFillButton title="Wert aus Vorlage übernehmen" onclick={getAutoFillValues} />
     {/if}

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -47,7 +47,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark}>
     {#if metadataDescription}
       <AutoFillButton title="Wert aus Vorlage übernehmen" onclick={getAutoFillValues} />
     {/if}

--- a/src/lib/components/Form/service/Field/62_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeTitle.svelte
@@ -31,7 +31,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/63_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/63_FeatureTypeName.svelte
@@ -38,7 +38,7 @@
         }
       }}
     />
-    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/65_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeName.svelte
@@ -30,7 +30,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/66_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeAlias.svelte
@@ -30,7 +30,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">

--- a/src/lib/components/Form/service/Field/67_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/67_AttributeDatatype.svelte
@@ -52,7 +52,7 @@
         }
       }}
     />
-    <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+    <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>
 {/if}
 

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -32,7 +32,7 @@
       }
     }}
   />
-  <FieldTools noCopyButton key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
+  <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
Introduce a `getCopyValue` method for HVD categories to get the german translation and add a copy button to all service input fields, enhancing user experience by allowing easy copying of values.