### PR TITLE
Fix autosave for new FeatureTypes

### DIFF
--- a/src/lib/components/Form/service/FeatureTypeForm.svelte
+++ b/src/lib/components/Form/service/FeatureTypeForm.svelte
@@ -61,6 +61,7 @@
       }
     ];
     activeTabIndex = featureTypes.length - 1;
+    onChange(featureTypes);
   }
 
   function removeFeatureType(index: number, evt: MouseEvent) {


### PR DESCRIPTION
Ensure that newly added FeatureTypes trigger the onChange function to save immediately.