### PR TITLE
Fix readonly-view by adding missing fields and labels

### DIFF
--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -1276,7 +1276,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     validatorExtraParams: ['isoMetadata.metadataProfile'],
     validator: (val: string[], extraParams) => {
       const metadataProfile = extraParams?.['isoMetadata.metadataProfile'];
-      if (metadataProfile === 'ISO') {
+      if (metadataProfile !== 'INSPIRE_HARMONISED') {
         return { valid: true };
       }
       if (!isDefined(val)) {

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -919,28 +919,28 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     required: false
   },
   {
-    profileId: 47,
+    profileId: 75,
     key: 'isoMetadata.services.legendImage.url',
     validator: optionalValidator,
     section: 'services',
     required: false
   },
   {
-    profileId: 47,
+    profileId: 76,
     key: 'isoMetadata.services.legendImage.format',
     validator: optionalValidator,
     section: 'services',
     required: false
   },
   {
-    profileId: 47,
+    profileId: 77,
     key: 'isoMetadata.services.legendImage.width',
     validator: optionalValidator,
     section: 'services',
     required: false
   },
   {
-    profileId: 47,
+    profileId: 78,
     key: 'isoMetadata.services.legendImage.height',
     validator: optionalValidator,
     section: 'services',

--- a/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
@@ -16,6 +16,10 @@
   let { value, onChange }: ServiceTypeProps = $props();
 
   const fieldConfig = getFieldConfig(47);
+  const fieldConfigUrl = getFieldConfig(75);
+  const fieldConfigFormat = getFieldConfig(76);
+  const fieldConfigWidth = getFieldConfig(77);
+  const fieldConfigHeight = getFieldConfig(78);
   const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
 
@@ -38,19 +42,19 @@
       <div class="legend-text-fields">
         <div class="field-wrapper">
           <TextInput
-            label="Url"
+            label={fieldConfigUrl?.label}
             value={value?.url}
             onchange={(e: Event) => update('url', (e.target as HTMLInputElement).value)}
-            fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.url')}
+            fieldConfig={fieldConfigUrl}
           />
           <FieldTools value={value?.url} key={KEY} noCheckmark noHelpButton />
         </div>
         <div class="field-wrapper">
           <TextInput
-            label="Format"
+            label={fieldConfigFormat?.label}
             value={value?.format}
             onchange={(e: Event) => update('format', (e.target as HTMLInputElement).value)}
-            fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.format')}
+            fieldConfig={fieldConfigFormat}
           />
           <FieldTools value={value?.format} key={KEY} noCheckmark noHelpButton />
         </div>
@@ -58,19 +62,19 @@
       <div class="legend-size-fields">
         <div class="field-wrapper">
           <NumberInput
-            label="Breite"
+            label={fieldConfigWidth?.label}
             value={value?.width}
             onchange={(e: Event) => update('width', (e.target as HTMLInputElement).value)}
-            fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.width')}
+            fieldConfig={fieldConfigWidth}
           />
           <FieldTools value={value?.width} key={KEY} noCheckmark noHelpButton />
         </div>
         <div class="field-wrapper">
           <NumberInput
-            label="Höhe"
+            label={fieldConfigHeight?.label}
             value={value?.height}
             onchange={(e: Event) => update('height', (e.target as HTMLInputElement).value)}
-            fieldConfig={getFieldConfig(47, 'isoMetadata.services.legendImage.height')}
+            fieldConfig={fieldConfigHeight}
           />
           <FieldTools value={value?.height} key={KEY} noCheckmark noHelpButton />
         </div>

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -20,7 +20,7 @@
 
 <div class="featuretype-short-description-field">
   <TextAreaInput
-    label={fieldConfig?.label || 'Kurzbeschreibung'}
+    label={fieldConfig?.label}
     {value}
     maxlength={500}
     {fieldConfig}

--- a/src/lib/components/ReadOnly/DisplayFieldSnippets.svelte
+++ b/src/lib/components/ReadOnly/DisplayFieldSnippets.svelte
@@ -16,7 +16,7 @@
 
   import type { Option } from '$lib/models/form';
   import { toast } from 'svelte-french-toast';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { getFieldConfig, getFormContext } from '$lib/context/FormContext.svelte';
 
   export {
     defaultSnippet,
@@ -457,26 +457,31 @@
         {@const layers = getLayers(service, metadata)}
         <div class="list-item">
           <div class="list-item-field">
-            <strong>Titel</strong>
+            <!-- ServiceTitle -->
+            <strong>{getFieldConfig(59)?.label}</strong>
             <span class="list-item-value">{service.title}</span>
           </div>
           <div class="list-item-field">
-            <strong>Typ</strong>
+            <!-- Service-Type -->
+            <strong>{getFieldConfig(58)?.label}</strong>
             <span class="list-item-value">{service.serviceType}</span>
           </div>
           <div class="list-item-field">
-            <strong>Kurzbeschreibung</strong>
+            <!-- Service-ShortDescription -->
+            <strong>{getFieldConfig(60)?.label}</strong>
             <span class="list-item-value">{service.shortDescription}</span>
           </div>
           {#if service.serviceType === 'WMS' || service.serviceType === 'WMTS'}
             <div class="list-item-field">
-              <strong>Identifikator des Kartendienstes</strong>
+              <!-- Service-Workspace -->
+              <strong>{getFieldConfig(45)?.label}</strong>
               <span class="list-item-value">{service.workspace}</span>
             </div>
           {/if}
-          {#if service.serviceType !== 'ATOM'}
+          {#if service.serviceType === 'WMS' || service.serviceType === 'WMTS'}
             <div class="list-item-field">
-              <strong>Vorschau</strong>
+              <!-- Service-Preview -->
+              <strong>{getFieldConfig(46)?.label}</strong>
               <span class="list-item-value">
                 {#await replaceVariable(service.preview)}
                   Lädt ...
@@ -488,12 +493,14 @@
               </span>
             </div>
           {/if}
-          {#if service.serviceType !== 'ATOM'}
+          {#if service.serviceType === 'WMS' || service.serviceType === 'WMTS'}
             <div class="list-item-field">
-              <strong>Gesamtlegende</strong>
+              <!-- Service-LegendImage -->
+              <strong>{getFieldConfig(53)?.label}</strong>
               <div class="list">
                 <div class="list-item-field">
-                  <strong>Url</strong>
+                  <!-- Service-LegendImage-Url -->
+                  <strong>{getFieldConfig(75)?.label}</strong>
                   <span class="list-item-value">
                     {#await replaceVariable(service.legendImage?.url)}
                       Lädt ...
@@ -505,7 +512,8 @@
                   </span>
                 </div>
                 <div class="list-item-field">
-                  <strong>Format</strong>
+                  <!-- Service-LegendImage-Format -->
+                  <strong>{getFieldConfig(76)?.label}</strong>
                   <span class="list-item-value">
                     {#if service.legendImage?.format}
                       {service.legendImage.format}
@@ -515,7 +523,8 @@
                   </span>
                 </div>
                 <div class="list-item-field">
-                  <strong>Breite</strong>
+                  <!-- Service-LegendImage-Width -->
+                  <strong>{getFieldConfig(77)?.label}</strong>
                   <span class="list-item-value">
                     {#if service.legendImage?.width}
                       {service.legendImage.width}
@@ -525,7 +534,8 @@
                   </span>
                 </div>
                 <div class="list-item-field">
-                  <strong>Höhe</strong>
+                  <!-- Service-LegendImage-Height -->
+                  <strong>{getFieldConfig(78)?.label}</strong>
                   <span class="list-item-value">
                     {#if service.legendImage?.height}
                       {service.legendImage.height}
@@ -554,12 +564,19 @@
                 {#each service?.featureTypes || [] as featureType}
                   <div class="list-item">
                     <div class="list-item-field">
-                      <strong>Feature-Typ</strong>
+                      <!-- FeatureType-Name -->
+                      <strong>{getFieldConfig(62)?.label}</strong>
                       <span class="list-item-value">{featureType.name}</span>
                     </div>
                     <div class="list-item-field">
-                      <strong>Feature-Typ-Alias</strong>
+                      <!-- FeatureType-Title -->
+                      <strong>{getFieldConfig(63)?.label}</strong>
                       <span class="list-item-value">{featureType.title}</span>
+                    </div>
+                    <div class="list-item-field">
+                      <!-- FeatureType-ShortDescription -->
+                      <strong>{getFieldConfig(69)?.label}</strong>
+                      <span class="list-item-value">{featureType.shortDescription}</span>
                     </div>
                     {#if featureType?.columns}
                       <div class="list-item-field">
@@ -568,15 +585,18 @@
                           {#each featureType?.columns || [] as columnInfo}
                             <div class="list-item">
                               <div class="list-item-field">
-                                <strong>Attribut-Name</strong>
+                                <!-- Attribute-Name -->
+                                <strong>{getFieldConfig(65)?.label}</strong>
                                 <span class="list-item-value">{columnInfo.name}</span>
                               </div>
                               <div class="list-item-field">
-                                <strong>Attribut-Alias</strong>
+                                <!-- Attribute-Alias -->
+                                <strong>{getFieldConfig(66)?.label}</strong>
                                 <span class="list-item-value">{columnInfo.alias}</span>
                               </div>
                               <div class="list-item-field">
-                                <strong>Attribut-Typ</strong>
+                                <!-- Attribute-DataType -->
+                                <strong>{getFieldConfig(67)?.label}</strong>
                                 <span class="list-item-value">{columnInfo.type}</span>
                               </div>
                             </div>
@@ -597,23 +617,28 @@
                 {#each layers || [] as layer}
                   <div class="list-item">
                     <div class="list-item-field">
-                      <strong>Titel der Kartenebene</strong>
+                      <!-- Layer-Title -->
+                      <strong>{getFieldConfig(49)?.label}</strong>
                       <span class="list-item-value">{layer.title}</span>
                     </div>
                     <div class="list-item-field">
-                      <strong>Name der Kartenebene</strong>
+                      <!-- Layer-Name -->
+                      <strong>{getFieldConfig(50)?.label}</strong>
                       <span class="list-item-value">{layer.name}</span>
                     </div>
                     <div class="list-item-field">
-                      <strong>Titel des Styles</strong>
-                      <span class="list-item-value">{layer.styleTitle}</span>
-                    </div>
-                    <div class="list-item-field">
-                      <strong>Name des Styles</strong>
+                      <!-- Layer-StyleName -->
+                      <strong>{getFieldConfig(52)?.label}</strong>
                       <span class="list-item-value">{layer.styleName}</span>
                     </div>
                     <div class="list-item-field">
-                      <strong>Legende</strong>
+                      <!-- Layer-StyleTitle -->
+                      <strong>{getFieldConfig(51)?.label}</strong>
+                      <span class="list-item-value">{layer.styleTitle}</span>
+                    </div>
+                    <div class="list-item-field">
+                      <!-- Layer-LegendImage -->
+                      <strong>{getFieldConfig(53)?.label}</strong>
                       <span class="list-item-value">
                         {#await replaceVariable(layer.legendImage)}
                           Lädt ...
@@ -625,15 +650,18 @@
                       </span>
                     </div>
                     <div class="list-item-field">
-                      <strong>Kurzbeschreibung</strong>
+                      <!-- Layer-ShortDescription -->
+                      <strong>{getFieldConfig(54)?.label}</strong>
                       <span class="list-item-value">{layer.shortDescription}</span>
                     </div>
                     <div class="list-item-field">
-                      <strong>Ablageort der Daten</strong>
+                      <!-- Layer-DataSource -->
+                      <strong>{getFieldConfig(55)?.label}</strong>
                       <span class="list-item-value">{layer.datasource}</span>
                     </div>
                     <div class="list-item-field">
-                      <strong>sekundäre Datenhaltung</strong>
+                      <!-- Layer-SecondaryDataSource -->
+                      <strong>{getFieldConfig(56)?.label}</strong>
                       <span class="list-item-value">{layer.secondaryDatasource}</span>
                     </div>
                   </div>

--- a/src/lib/components/ReadOnly/DisplayFieldSnippets.svelte
+++ b/src/lib/components/ReadOnly/DisplayFieldSnippets.svelte
@@ -20,36 +20,38 @@
 
   export {
     defaultSnippet,
-    isoMetadataTitle as 'isoMetadata.title',
-    isoMetadataDescription as 'isoMetadata.description',
-    isoMetadataKeywords as 'isoMetadata.keywords',
-    isoMetadataPreview as 'isoMetadata.preview',
-    isoMetadataContacts as 'isoMetadata.pointsOfContact',
-    isoMetadataMetadataProfile as 'isoMetadata.metadataProfile',
-    isoMetadataTermsOfUse as 'isoMetadata.termsOfUseId',
-    isoMetadataInspireTheme as 'isoMetadata.inspireTheme',
+    clientMetadataPrivacy as 'clientMetadata.privacy',
     isoMetadataAnnexTheme as 'isoMetadata.annexTheme',
-    isoMetadataQualityReportCheck as 'isoMetadata.qualityReportCheck',
-    isoMetadataTopicCategory as 'isoMetadata.topicCategory',
+    isoMetadataContacts as 'isoMetadata.pointsOfContact',
+    isoMetadataContentDescription as 'isoMetadata.contentDescription',
+    isoMetadataContentDescriptions as 'isoMetadata.contentDescriptions',
     isoMetadataCreated as 'isoMetadata.created',
-    isoMetadataPublished as 'isoMetadata.published',
+    isoMetadataCrs as 'isoMetadata.crs',
+    isoMetadataDescription as 'isoMetadata.description',
+    isoMetadataExtent as 'isoMetadata.extent',
+    isoMetadataHighValueDataCategory as 'isoMetadata.highValueDataCategory',
+    isoMetadataHighValueDataset as 'isoMetadata.highValueDataset',
+    isoMetadataInspireAnnexVersion as 'isoMetadata.inspireAnnexVersion',
+    isoMetadataInspireFormatName as 'isoMetadata.inspireFormatName',
+    isoMetadataInspireTheme as 'isoMetadata.inspireTheme',
+    isoMetadataKeywords as 'isoMetadata.keywords',
+    isoMetadataLineage as 'isoMetadata.lineage',
     isoMetadataMaintenanceFrequency as 'isoMetadata.maintenanceFrequency',
+    isoMetadataMetadataProfile as 'isoMetadata.metadataProfile',
     isoMetadataModified as 'isoMetadata.modified',
+    isoMetadataPreview as 'isoMetadata.preview',
+    isoMetadataPublished as 'isoMetadata.published',
+    isoMetadataQualityReportCheck as 'isoMetadata.qualityReportCheck',
+    isoMetadataResolutions as 'isoMetadata.resolutions',
+    isoMetadataServices as 'isoMetadata.services',
+    isoMetadataTechnicalDescription as 'isoMetadata.technicalDescription',
+    isoMetadataTermsOfUse as 'isoMetadata.termsOfUseId',
+    isoMetadataTitle as 'isoMetadata.title',
+    isoMetadataTopicCategory as 'isoMetadata.topicCategory',
+    isoMetadataValid as 'isoMetadata.valid',
     isoMetadataValidFrom as 'isoMetadata.validFrom',
     isoMetadataValidTo as 'isoMetadata.validTo',
-    isoMetadataValid as 'isoMetadata.valid',
-    technialMetadataDeliveredCrs as 'isoMetadata.deliveredCoordinateSystem',
-    isoMetadataCrs as 'isoMetadata.crs',
-    isoMetadataExtent as 'isoMetadata.extent',
-    isoMetadataResolutions as 'isoMetadata.resolutions',
-    isoMetadataContentDescription as 'isoMetadata.contentDescription',
-    isoMetadataTechnicalDescription as 'isoMetadata.technicalDescription',
-    isoMetadataLineage as 'isoMetadata.lineage',
-    isoMetadataContentDescriptions as 'isoMetadata.contentDescriptions',
-    isoMetadataServices as 'isoMetadata.services',
-    clientMetadataPrivacy as 'clientMetadata.privacy',
-    isoMetadataHighValueDataset as 'isoMetadata.highValueDataset',
-    isoMetadataHighValueDataCategory as 'isoMetadata.highValueDataCategory',
+    technicalMetadataDeliveredCrs as 'technicalMetadata.deliveredCrs',
     technicalMetadataCategories as 'technicalMetadata.categories'
   };
 
@@ -292,11 +294,19 @@
 {/snippet}
 
 {#snippet isoMetadataAnnexTheme(value: string)}
-  {value ? JSON.stringify(value) : DEFAULT_NULL_STRING}
+  {value ? value.toString() : DEFAULT_NULL_STRING}
+{/snippet}
+
+{#snippet isoMetadataInspireFormatName(value: string)}
+  {value ? value.toString() : DEFAULT_NULL_STRING}
+{/snippet}
+
+{#snippet isoMetadataInspireAnnexVersion(value: string)}
+  {value ? value.toString() : DEFAULT_NULL_STRING}
 {/snippet}
 
 {#snippet isoMetadataQualityReportCheck(value: string)}
-  {value ? JSON.stringify(value) : DEFAULT_NULL_STRING}
+  {value ? 'Ja' : 'Nein'}
 {/snippet}
 
 {#snippet isoMetadataTopicCategory(value: string[])}
@@ -350,7 +360,7 @@
   {value ? new Date(value).toLocaleDateString() : DEFAULT_NULL_STRING}
 {/snippet}
 
-{#snippet technialMetadataDeliveredCrs(value: string)}
+{#snippet technicalMetadataDeliveredCrs(value: string)}
   {value || DEFAULT_NULL_STRING}
 {/snippet}
 
@@ -446,7 +456,6 @@
   {/if}
 {/snippet}
 
-// TODO: get labels from fieldconfigs
 {#snippet isoMetadataServices(services: Service[], metadata: MetadataCollection)}
   {#if !services?.length}
     {DEFAULT_NULL_STRING}

--- a/src/lib/components/ReadOnly/MetadataDisplay.svelte
+++ b/src/lib/components/ReadOnly/MetadataDisplay.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+  import { getValue } from '../../context/FormContext.svelte';
   import CommentsDisplay from './CommentsDisplay.svelte';
   import DisplayField from './DisplayField.svelte';
+
+  const metadataProfile = $derived(getValue('isoMetadata.metadataProfile'));
+  const highValueDataset = $derived(getValue('isoMetadata.highValueDataset'));
 </script>
 
 <div class="metadata-display">
@@ -21,11 +25,20 @@
       <DisplayField key="clientMetadata.privacy" profileId={4} />
       <DisplayField key="isoMetadata.termsOfUseId" profileId={25} />
       <DisplayField key="isoMetadata.termsOfUseSource" profileId={26} />
-      <DisplayField key="isoMetadata.inspireTheme" profileId={7} />
-      <DisplayField key="isoMetadata.inspireAnnexVersion" profileId={38} />
+      {#if metadataProfile === 'INSPIRE_HARMONISED' || metadataProfile === 'INSPIRE_IDENTIFIED'}
+        <DisplayField key="isoMetadata.inspireTheme" profileId={7} />
+      {/if}
+      {#if metadataProfile === 'INSPIRE_HARMONISED'}
+        <DisplayField key="isoMetadata.inspireFormatName" profileId={70} />
+      {/if}
+      {#if metadataProfile === 'INSPIRE_HARMONISED'}
+        <DisplayField key="isoMetadata.inspireAnnexVersion" profileId={38} />
+      {/if}
       <DisplayField key="isoMetadata.valid" profileId={37} />
       <DisplayField key="isoMetadata.highValueDataset" profileId={6} />
-      <DisplayField key="isoMetadata.highValueDataCategory" profileId={8} />
+      {#if highValueDataset === true}
+        <DisplayField key="isoMetadata.highValueDataCategory" profileId={8} />
+      {/if}
       <DisplayField key="isoMetadata.topicCategory" profileId={13} />
     </section>
     <section id="temp_and_spatial">


### PR DESCRIPTION
Add necessary fields and labels to the readonly-view for better clarity and usability. Update profile IDs and ensure proper configuration retrieval for each field.

It also adds conditonality to some displayfields.