### PR TITLE
Allow deletion of remaining date fields (follow-up to PR #263)

### DIFF
--- a/src/lib/components/Form/Field/09_CreatedField.svelte
+++ b/src/lib/components/Form/Field/09_CreatedField.svelte
@@ -11,12 +11,7 @@
 
   const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
-  let value = $state('');
-  $effect(() => {
-    if (valueFromData && !value) {
-      value = new Date(valueFromData).toISOString().split('T')[0];
-    }
-  });
+  let value = $derived(valueFromData ? new Date(valueFromData).toISOString().split('T')[0] : '');
 
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(9);

--- a/src/lib/components/Form/Field/09_CreatedField.svelte
+++ b/src/lib/components/Form/Field/09_CreatedField.svelte
@@ -11,20 +11,7 @@
 
   const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
-  let value = $state('');
-  let initialized = false;
-
-  // TODO: this should be replaced by deriving "value". This
-  // should be possible after svelte is updated to the latest version
-  // https://github.com/gdi-be/mde-client/pull/261
-  $effect(() => {
-    if (!initialized) {
-      if (valueFromData) {
-        value = new Date(valueFromData).toISOString().split('T')[0];
-      }
-      initialized = true;
-    }
-  });
+  let value = $derived(valueFromData ? new Date(valueFromData).toISOString().split('T')[0] : '');
 
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(9);

--- a/src/lib/components/Form/Field/10_PublishedField.svelte
+++ b/src/lib/components/Form/Field/10_PublishedField.svelte
@@ -11,17 +11,7 @@
 
   const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
-  let value = $state('');
-  let initialized = false;
-
-  // TODO: this should be replaced by deriving "value". This
-  // should be possible after svelte is updated to the latest version
-  // https://github.com/gdi-be/mde-client/pull/261
-  $effect(() => {
-    if (valueFromData && !initialized) {
-      value = new Date(valueFromData).toISOString().split('T')[0];
-    }
-  });
+  let value = $derived(valueFromData ? new Date(valueFromData).toISOString().split('T')[0] : '');
 
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(10);

--- a/src/lib/components/Form/Field/10_PublishedField.svelte
+++ b/src/lib/components/Form/Field/10_PublishedField.svelte
@@ -11,20 +11,7 @@
 
   const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
-  let value = $state('');
-  let initialized = false;
-
-  // TODO: this should be replaced by deriving "value". This
-  // should be possible after svelte is updated to the latest version
-  // https://github.com/gdi-be/mde-client/pull/261
-  $effect(() => {
-    if (!initialized) {
-      if (valueFromData) {
-        value = new Date(valueFromData).toISOString().split('T')[0];
-      }
-      initialized = true;
-    }
-  });
+  let value = $derived(valueFromData ? new Date(valueFromData).toISOString().split('T')[0] : '');
 
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(10);

--- a/src/lib/components/Form/Field/11_LastUpdatedField.svelte
+++ b/src/lib/components/Form/Field/11_LastUpdatedField.svelte
@@ -19,20 +19,17 @@
 
   const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY, metadata));
-  let value = $state('');
-
-  $effect(() => {
-    if (valueFromData && !value) {
-      value = new Date(valueFromData).toISOString().split('T')[0];
-    }
-  });
+  let value = $derived(valueFromData ? new Date(valueFromData).toISOString().split('T')[0] : '');
   const fieldConfig = MetadataService.getFieldConfig<string>(11);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   let showCheckmark = $state(false);
 
   const onBlur = async () => {
-    const response = await MetadataService.persistValue(KEY, new Date(value!).toISOString());
+    const response = await MetadataService.persistValue(
+      KEY,
+      value ? new Date(value!).toISOString() : ''
+    );
     if (response.ok) {
       showCheckmark = true;
     }

--- a/src/lib/components/Form/Field/11_LastUpdatedField.svelte
+++ b/src/lib/components/Form/Field/11_LastUpdatedField.svelte
@@ -19,20 +19,7 @@
 
   const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY, metadata));
-  let value = $state('');
-  let initialized = false;
-
-  // TODO: this should be replaced by deriving "value". This
-  // should be possible after svelte is updated to the latest version
-  // https://github.com/gdi-be/mde-client/pull/261
-  $effect(() => {
-    if (!initialized) {
-      if (valueFromData) {
-        value = new Date(valueFromData).toISOString().split('T')[0];
-      }
-      initialized = true;
-    }
-  });
+  let value = $derived(valueFromData ? new Date(valueFromData).toISOString().split('T')[0] : '');
   const fieldConfig = MetadataService.getFieldConfig<string>(11);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 

--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -13,20 +13,14 @@
 
   const { getValue } = getFormContext();
   const startValueFromData = $derived(getValue<string>(FROM_KEY));
-  let startValue = $state('');
-  $effect(() => {
-    if (startValueFromData && !startValue) {
-      startValue = new Date(startValueFromData).toISOString().split('T')[0];
-    }
-  });
+  let startValue = $derived(
+    startValueFromData ? new Date(startValueFromData).toISOString().split('T')[0] : ''
+  );
 
   const endValueFromData = $derived(getValue<string>(TO_KEY));
-  let endValue = $state('');
-  $effect(() => {
-    if (endValueFromData && !endValue) {
-      endValue = new Date(endValueFromData).toISOString().split('T')[0];
-    }
-  });
+  let endValue = $derived(
+    endValueFromData ? new Date(endValueFromData).toISOString().split('T')[0] : ''
+  );
 
   let showCheckmark = $state(false);
   const fromFieldConfig = MetadataService.getFieldConfig<string>(12);

--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -13,36 +13,14 @@
 
   const { getValue, updateFormState } = getFormContext();
   const startValueFromData = $derived(getValue<string>(FROM_KEY));
-  let startValue = $state('');
-  let startInitialized = false;
-
-  // TODO: this should be replaced by deriving "startValue". This
-  // should be possible after svelte is updated to the latest version
-  // https://github.com/gdi-be/mde-client/pull/261
-  $effect(() => {
-    if (!startInitialized) {
-      if (startValueFromData) {
-        startValue = new Date(startValueFromData).toISOString().split('T')[0];
-      }
-      startInitialized = true;
-    }
-  });
+  let startValue = $derived(
+    startValueFromData ? new Date(startValueFromData).toISOString().split('T')[0] : ''
+  );
 
   const endValueFromData = $derived(getValue<string>(TO_KEY));
-  let endValue = $state('');
-  let endInitialized = false;
-
-  // TODO: this should be replaced by deriving "endValue". This
-  // should be possible after svelte is updated to the latest version
-  // https://github.com/gdi-be/mde-client/pull/261
-  $effect(() => {
-    if (!endInitialized) {
-      if (endValueFromData) {
-        endValue = new Date(endValueFromData).toISOString().split('T')[0];
-      }
-      endInitialized = true;
-    }
-  });
+  let endValue = $derived(
+    endValueFromData ? new Date(endValueFromData).toISOString().split('T')[0] : ''
+  );
 
   let showCheckmark = $state(false);
   const fromFieldConfig = MetadataService.getFieldConfig<string>(12);


### PR DESCRIPTION
This PR is a follow-up to PR #263 (Fix date deletion and improve keyword display) and applies the same date-deletion fix to the remaining date fields in the "Zeitliche und Räumliche Angaben" section. Date values can now be cleared in the form.

Additionally, the TODO in `10_PublishedField.svelte` was resolved by implementing the intended _derived_-value approach now that the required Svelte update is available (#261).