### PR TITLE
test: edit mock to test duplicated iso themes

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -78,7 +78,10 @@ export const fetchMock = vi.fn(async (input: string | Request | URL, init?: Requ
 
   if (url === '/data/iso_themes') {
     return Promise.resolve(
-      new Response(JSON.stringify([{ isoID: 'Land use', isoName: 'Land use' }]), { status: 200 })
+      new Response(JSON.stringify([
+        { isoID: 'Land use', isoName: 'Land use' },
+        { isoID: 'Land use', isoName: 'Land use' }
+      ]), { status: 200 })
     );
   }
 


### PR DESCRIPTION
Minor change in the test setup. Puts duplications in the mock iso themes to test if they show up in the list. 
With this the test for "13_TopicCategory" will fail and should pass again with #271.
<img width="1204" height="144" alt="image" src="https://github.com/user-attachments/assets/752d5ee7-4a17-4f96-994f-e91224b85921" />
