### PR TITLE
Make atom service ID a required field

### DIFF
--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -744,8 +744,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     validator: (workspace: Service['workspace'], extraParams) => {
       const highestRole = extraParams?.['HIGHEST_ROLE'] as string;
       const required = ['MdeEditor', 'MdeAdministrator'].includes(highestRole);
-      const service = extraParams?.['PARENT_VALUE'];
-      if (!required || (service?.serviceType === 'ATOM' && !isDefined(workspace))) {
+      if (!required) {
         return { valid: true };
       }
       const valid = !!(isDefined(workspace) && /^[a-zA-Z0-9_]+$/.test(workspace));

--- a/tests/fixtures/metadata1.ts
+++ b/tests/fixtures/metadata1.ts
@@ -54,6 +54,7 @@ export default {
       },
       {
         id: 'svc-2',
+        workspace: 'workspace_atom',
         title: 'ewfewf',
         shortDescription: 'ewfewfew',
         serviceIdentification: '3a5b3081-a5e0-4133-ad18-ea756331e33f',

--- a/tests/integration/Workflow.integration.spec.ts
+++ b/tests/integration/Workflow.integration.spec.ts
@@ -37,7 +37,7 @@ describe('Metadata Workflow - Integration test', () => {
       render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeDataOwner'
           }
@@ -53,7 +53,7 @@ describe('Metadata Workflow - Integration test', () => {
       render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: 'someone-else',
             responsibleRole: 'MdeDataOwner',
             approved: false
@@ -72,7 +72,7 @@ describe('Metadata Workflow - Integration test', () => {
       render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             approved: true,
             responsibleRole: 'MdeEditor'
@@ -89,7 +89,7 @@ describe('Metadata Workflow - Integration test', () => {
       render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: 'current-user-id',
             responsibleRole: 'MdeQualityAssurance'
           }
@@ -117,7 +117,7 @@ describe('Metadata Workflow - Integration test', () => {
       const { unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeDataOwner'
           }
@@ -136,7 +136,7 @@ describe('Metadata Workflow - Integration test', () => {
       const { unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeEditor'
           }
@@ -158,7 +158,7 @@ describe('Metadata Workflow - Integration test', () => {
       const { unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeQualityAssurance',
             approved: false
@@ -185,7 +185,7 @@ describe('Metadata Workflow - Integration test', () => {
       const { unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeEditor',
             approved: true
@@ -215,7 +215,7 @@ describe('Metadata Workflow - Integration test', () => {
       let { unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: '',
             responsibleRole: 'MdeDataOwner'
           }
@@ -232,7 +232,7 @@ describe('Metadata Workflow - Integration test', () => {
       ({ unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeDataOwner'
           }
@@ -249,7 +249,7 @@ describe('Metadata Workflow - Integration test', () => {
       ({ unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeEditor'
           }
@@ -265,7 +265,7 @@ describe('Metadata Workflow - Integration test', () => {
       ({ unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeEditor'
           }
@@ -282,7 +282,7 @@ describe('Metadata Workflow - Integration test', () => {
       ({ unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeQualityAssurance',
             approved: false
@@ -307,7 +307,7 @@ describe('Metadata Workflow - Integration test', () => {
       ({ unmount } = render(FormHarness, {
         props: {
           metadata: {
-            ...metadata1,
+            ...structuredClone(metadata1),
             assignedUserId: TEST_USER_ID,
             responsibleRole: 'MdeEditor',
             approved: true


### PR DESCRIPTION
- The ATOM special handling has been removed from the validator
- As a result, the Service ID ("Dienst-ID") is now also required for ATOM whenever the role (`MdeEditor`/`MdeAdministrator`) triggers this requirement
- In addition, the variable service, which had become redundant as a result, has been removed

@hwbllmnn please review