### PR TITLE
Refine assignment logic (#29278)

### DIFF
--- a/src/lib/components/AssignmentDialog.svelte
+++ b/src/lib/components/AssignmentDialog.svelte
@@ -30,8 +30,10 @@
   const canAssignToDataOwner = $derived(
     // Admin can do anything
     highestRole === 'MdeAdministrator' ||
-      // Editors are responsible and I'm an Editor
-      (responsibleRole === 'MdeEditor' && highestRole === 'MdeEditor')
+      (assignedToMe &&
+        // Editors are responsible and I'm an Editor
+        responsibleRole === 'MdeEditor' &&
+        highestRole === 'MdeEditor')
   );
 
   const canAssignToEditor = $derived(
@@ -44,12 +46,14 @@
   const canAssignToQualityAssurance = $derived(
     // Admin can do anything
     highestRole === 'MdeAdministrator' ||
-      // Editors are responsible and I'm an Editor
-      (responsibleRole === 'MdeEditor' && highestRole === 'MdeEditor')
+      (assignedToMe &&
+        // Editors are responsible and I'm an Editor
+        responsibleRole === 'MdeEditor' &&
+        highestRole === 'MdeEditor')
   );
 
   const canApproveMetadata = $derived(
-    ['MdeAdministrator', 'MdeQualityAssurance'].includes(highestRole)
+    highestRole === 'MdeAdministrator' || (assignedToMe && highestRole === 'MdeQualityAssurance')
   );
 
   const canAssignToMe = $derived(canAssignSelf(token, metadata));


### PR DESCRIPTION
See also [#29278](https://redmine.intranet.terrestris.de/issues/29278).

This patch updates assignment visibility and permissions.
Administrator keeps full access, while role-specific actions now require the metadata record to be personally assigned to the current user (`assignedToMe`).