### PR TITLE
Add maintenance release configuration for versioned branches

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -22,6 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Use maintenance release config on maintenance branches
+        if: ${{ startsWith(github.ref_name, 'v') && endsWith(github.ref_name, '.x') }}
+        run: cp .releaserc-maintenance.yml .releaserc.yml
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.releaserc-maintenance.yml
+++ b/.releaserc-maintenance.yml
@@ -1,0 +1,23 @@
+branches:
+  - main
+  - name: v6.1.x
+    range: '6.1.x'
+    channel: false
+
+plugins:
+  - - '@semantic-release/commit-analyzer'
+    - releaseRules:
+        - breaking: true
+          release: major
+        - type: feat
+          release: patch
+        - type: fix
+          release: patch
+        - type: perf
+          release: patch
+        - revert: true
+          release: patch
+  - '@semantic-release/release-notes-generator'
+  - '@semantic-release/changelog'
+  - '@semantic-release/github'
+  - '@semantic-release/git'


### PR DESCRIPTION
Adds a separate `.releaserc-maintenance.yml` that overrides `feat:` commits to produce patch releases instead of minor ones. The release workflow automatically switches to this config when running on maintenance branches matching the `v*.x` pattern (e.g. `v6.1.x`).

This ensures releases on `v6.1.x` stay within the valid `>=6.1.3 <6.2.0` range while `main` retains its default behavior.