### PR TITLE
Progress bar display and sync issues (#29545, #29500)

### DIFF
--- a/src/lib/components/Form/Field/01_TitleField.svelte
+++ b/src/lib/components/Form/Field/01_TitleField.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
+  import {
+    FORMSTATE_CONTEXT,
+    getFormContext,
+    type FormState
+  } from '$lib/context/FormContext.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import { page } from '$app/state';
+  import { getContext } from 'svelte';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.title';
 
   const formContext = $derived(getFormContext());
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(formContext.getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -18,6 +24,24 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(1);
   let validationResult = $derived(fieldConfig?.validator(value));
+
+  $effect(() => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    if (formState.metadata.isoMetadata.title === value) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        title: value
+      }
+    };
+  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
   import type { ValidationResult } from '../FieldsConfig';
   import FieldTools from '../FieldTools.svelte';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
+  import {
+    FORMSTATE_CONTEXT,
+    getFormContext,
+    type FormState
+  } from '$lib/context/FormContext.svelte';
   import TextAreaInput from '../Inputs/TextAreaInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import { page } from '$app/state';
+  import { getContext } from 'svelte';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.description';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -19,6 +25,24 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(2);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+
+  $effect(() => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    if (formState.metadata.isoMetadata.description === value) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        description: value
+      }
+    };
+  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/15_KeywordsField.svelte
+++ b/src/lib/components/Form/Field/15_KeywordsField.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import { onMount } from 'svelte';
+  import { getContext } from 'svelte';
   import Chip, { Set as ChipSet, Text, TrailingIcon } from '@smui/chips';
   import Autocomplete from '@smui-extra/autocomplete';
   import Dialog, { Actions, Content, Title } from '@smui/dialog';
@@ -23,6 +25,7 @@
   let { metadataid } = page.params;
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   let value = $state<string[]>([]);
   const valueFromData = $derived(getValue<Keywords>(KEY));
   $effect(() => {
@@ -35,7 +38,10 @@
   let uniqueKeywords = $derived(Array.from(new Set([...autoKeywords, ...value])));
   let searchValue = $state('');
   const fieldConfig = MetadataService.getFieldConfig<Keywords>(15);
-  let validationResult = $derived(fieldConfig?.validator(valueFromData));
+  const toKeywords = (keywords: string[]): Keywords => ({
+    default: keywords.map((entry) => ({ keyword: entry }))
+  });
+  let validationResult = $derived(fieldConfig?.validator(toKeywords(value)));
 
   let dialogOpen = $state(false);
   let newKeyword = $state('');
@@ -99,14 +105,19 @@
   };
 
   const persistKeywords = async () => {
+    const keywords: Keywords = toKeywords(value);
+
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          keywords
+        }
+      };
+    }
+
     if (validationResult?.valid === false) return;
-    const keywords: Keywords = valueFromData || {
-      default: []
-    };
-    keywords.default = value
-      // filter autokeywords from value to avoid duplicates
-      .filter((kw) => !autoKeywords.includes(kw))
-      .map((entry) => ({ keyword: entry }));
 
     const response = await MetadataService.persistValue(KEY, keywords);
     if (response.ok) {

--- a/src/lib/components/Form/Field/18_ExtentField.svelte
+++ b/src/lib/components/Form/Field/18_ExtentField.svelte
@@ -7,7 +7,7 @@
   import Button, { Icon, Label } from '@smui/button';
   import SelectInput from '../Inputs/SelectInput.svelte';
   import { getHighestRole, registerCRSCodes, transformExtent } from '$lib/util';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { toast } from 'svelte-french-toast';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import type { CRSOption } from '$lib/models/api';
@@ -158,8 +158,9 @@
             type="button"
             variant={matchingOption?.title === option.title ? 'raised' : 'text'}
             title={option.title}
-            onclick={() => {
+            onclick={async () => {
               value4326 = option.value;
+              await tick();
               sendValue();
             }}
           >

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -2,6 +2,7 @@
   import type { Contact, Contacts } from '$lib/models/metadata';
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
@@ -12,6 +13,7 @@
   import { page } from '$app/state';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
+  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -21,6 +23,7 @@
   const KEY = 'isoMetadata.pointsOfContact';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   let contacts = $state<Contact[]>([]);
   const valueFromData = $derived(getValue<Contacts>(KEY));
 
@@ -84,6 +87,16 @@
   };
 
   const persistContacts = async (evt?: FocusEvent) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          pointsOfContact: contacts
+        }
+      };
+    }
+
     if (hasInvalidFields) {
       return;
     }

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -61,14 +61,31 @@
     !resolutionValidationResult?.valid && !scaleValidationResult?.valid
   );
 
+  const syncLocalResolutionState = () => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        resolutions: resolutionValue ? [resolutionValue] : null,
+        scale: scaleValue
+      }
+    };
+  };
+
   const clearAllValues = async () => {
     scaleValue = null;
     resolutionValue = null;
+    syncLocalResolutionState();
     await updateResolution(null);
     await updateScale(null);
   };
 
   const onBlur = async (event: FocusEvent) => {
+    syncLocalResolutionState();
     const target = event.target as HTMLInputElement;
     const minValue = target.getAttribute('min');
     const min = Number(minValue);

--- a/src/lib/components/Form/Field/29_PreviewField.svelte
+++ b/src/lib/components/Form/Field/29_PreviewField.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
+  import {
+    FORMSTATE_CONTEXT,
+    getFormContext,
+    type FormState
+  } from '$lib/context/FormContext.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import type { ValidationResult } from '../FieldsConfig';
   import { page } from '$app/state';
+  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.preview';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -19,6 +25,24 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(29);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+
+  $effect(() => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    if (formState.metadata.isoMetadata.preview === value) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        preview: value
+      }
+    };
+  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -2,6 +2,7 @@
   import type { Lineage, MetadataCollection } from '$lib/models/metadata';
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '../Inputs/TextInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
@@ -12,6 +13,7 @@
   import { getPopconfirm } from '$lib/context/PopConfirmContext.svelte';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
+  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -21,6 +23,7 @@
   const KEY = 'isoMetadata.lineage';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<Lineage[]>(KEY));
   let lineages = $state<Lineage[]>([]);
 
@@ -96,6 +99,8 @@
   };
 
   const persistLineages = async (evt?: FocusEvent) => {
+    syncLocalLineageState();
+
     if (hasInvalidFields) {
       return;
     }
@@ -118,6 +123,29 @@
       elementToFocus?.focus();
     }, 10);
   };
+
+  const syncLocalLineageState = () => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    const currentLineage = formState.metadata.isoMetadata.lineage || [];
+    if (JSON.stringify(currentLineage) === JSON.stringify(lineages)) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        lineage: lineages
+      }
+    };
+  };
+
+  $effect(() => {
+    syncLocalLineageState();
+  });
 
   const addItem = (evt: MouseEvent) => {
     evt.preventDefault();

--- a/src/lib/components/Form/Field/41_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/41_AdditionalInformation.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
@@ -11,6 +12,7 @@
   import { page } from '$app/state';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
+  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -20,6 +22,7 @@
   const KEY = 'isoMetadata.contentDescriptions';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<ContentDescription[]>(KEY));
   let contentDescriptions = $state<ContentDescription[]>([]);
 
@@ -57,6 +60,8 @@
   const urlFieldConfig = MetadataService.getFieldConfig<string>(44);
 
   const persistContentDescriptions = async (evt?: FocusEvent) => {
+    syncLocalContentDescriptionsState();
+
     if (hasInvalidFields) {
       return;
     }
@@ -74,6 +79,29 @@
       elementToFocus?.focus();
     }, 10);
   };
+
+  const syncLocalContentDescriptionsState = () => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    const currentContentDescriptions = formState.metadata.isoMetadata.contentDescriptions || [];
+    if (JSON.stringify(currentContentDescriptions) === JSON.stringify(contentDescriptions)) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        contentDescriptions
+      }
+    };
+  };
+
+  $effect(() => {
+    syncLocalContentDescriptionsState();
+  });
 
   const addItem = (evt: MouseEvent) => {
     evt.preventDefault();

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -125,8 +125,16 @@
     }
   });
 
-  const getProgressTitle = (progressInfo: ProgressInfo) => {
-    let baseText = `Fortschritt: ${Math.floor(progressInfo.progress * 100)} %`;
+  const getDisplayedProgress = (section: Section, progress: number) => {
+    if (section === 'services' && progress >= 0.98 && progress < 1) {
+      return 0.98;
+    }
+    return progress;
+  };
+
+  const getProgressTitle = (section: Section, progressInfo: ProgressInfo) => {
+    const displayedProgress = getDisplayedProgress(section, progressInfo.progress);
+    let baseText = `Fortschritt: ${Math.floor(displayedProgress * 100)} %`;
     return baseText;
   };
 </script>
@@ -146,9 +154,9 @@
           <Label>{label}</Label>
         </button>
         <LinearProgress
-          progress={progressInfo.progress}
+          progress={getDisplayedProgress(section, progressInfo.progress)}
           aria-label={label + ' Fortschritt'}
-          title={getProgressTitle(progressInfo)}
+          title={getProgressTitle(section, progressInfo)}
         />
       </div>
       {#if i + 1 < SECTIONS.length}

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -103,8 +103,7 @@
     formContext.clearActiveHelp();
 
     goto(`#${section}`, {
-      replaceState: true,
-      invalidateAll: true
+      replaceState: true
     });
     await tick();
   };

--- a/src/lib/components/Form/Inputs/TextAreaInput.svelte
+++ b/src/lib/components/Form/Inputs/TextAreaInput.svelte
@@ -50,6 +50,9 @@
   <textarea
     {maxlength}
     bind:value
+    oninput={(evt) => {
+      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLTextAreaElement });
+    }}
     onfocus={(evt) => {
       fieldHasFocus = true;
       onfocus?.(evt);

--- a/src/lib/components/Form/Inputs/TextInput.svelte
+++ b/src/lib/components/Form/Inputs/TextInput.svelte
@@ -53,6 +53,9 @@
   <input
     type="text"
     autocomplete="off"
+    oninput={(evt) => {
+      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLInputElement });
+    }}
     onfocus={(evt) => {
       fieldHasFocus = true;
       onfocus?.(evt);

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -20,12 +20,14 @@
   import { toast } from 'svelte-french-toast';
   import { invalidateAll } from '$app/navigation';
   import { logger } from 'loggisch';
+  import { getAccessToken } from '$lib/context/TokenContext.svelte';
+  import { getHighestRole } from '$lib/util';
 
   const t = $derived(page.data.t);
 
   export type ServiceFormProps = {
     service: Service;
-    onChange: (service: Service) => Promise<Response>;
+    onChange: (service: Service, persist?: boolean) => Promise<Response>;
   };
 
   let { service, onChange }: ServiceFormProps = $props();
@@ -33,6 +35,8 @@
   const { getValue } = getFormContext();
   const formContext = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formContext.metadata);
+  const token = $derived(getAccessToken());
+  const highestRole = $derived(getHighestRole(token));
 
   const layers = $derived.by((): Layer[] => {
     const layersMap: Record<string, Layer[]> = metadata?.clientMetadata?.layers;
@@ -67,13 +71,12 @@
       // Remove feature types associated with the service
       delete service.featureTypes;
     }
-    return onChange(service);
+    return onChange(service, true);
   }
 
-  async function set(key: string, value: Service[keyof Service]) {
+  async function set<K extends keyof Service>(key: K, value: Service[K]) {
     service = setNestedValue(service, key, value);
-
-    const response = await onChange(service);
+    const response = await onChange(service, shouldPersistFieldValue(key, value));
     if (response.ok) {
       if (key === 'serviceType') {
         onServiceTypeChange(value as ServiceType);
@@ -93,6 +96,42 @@
     }
     return response;
   }
+
+  const shouldPersistFieldValue = <K extends keyof Service>(key: K, value: Service[K]) => {
+    if (key === 'workspace') {
+      const fieldConfig = MetadataService.getFieldConfig<string>(45);
+      return fieldConfig?.validator(value as Service['workspace'], {
+        ['PARENT_VALUE']: service,
+        ['HIGHEST_ROLE']: highestRole
+      }).valid;
+    }
+    if (key === 'preview') {
+      const fieldConfig = MetadataService.getFieldConfig<string>(46);
+      return fieldConfig?.validator(value as Service['preview'], {
+        ['PARENT_VALUE']: service
+      }).valid;
+    }
+    if (key === 'title') {
+      const fieldConfig = MetadataService.getFieldConfig<string>(59);
+      return fieldConfig?.validator(value as Service['title']).valid;
+    }
+    if (key === 'shortDescription') {
+      const fieldConfig = MetadataService.getFieldConfig<string>(60);
+      return fieldConfig?.validator(value as Service['shortDescription']).valid;
+    }
+    if (key === 'featureTypes') {
+      const fieldConfig = MetadataService.getFieldConfig<Service['featureTypes']>(56);
+      return fieldConfig?.validator(value as Service['featureTypes'], {
+        ['PARENT_VALUE']: service
+      }).valid;
+    }
+    if (key === 'serviceType') {
+      const fieldConfig = MetadataService.getFieldConfig<ServiceType>(58);
+      return fieldConfig?.validator(value as Service['serviceType']).valid;
+    }
+
+    return true;
+  };
 
   async function onLayersChange(layers: Layer[]) {
     const serviceIdentification = service?.serviceIdentification;

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -145,7 +145,7 @@
     );
   }
 
-  async function updateService(id: string, newService: Service) {
+  async function updateService(id: string, newService: Service, persist = true) {
     if (!id || !newService) {
       return Promise.reject('Invalid parameters');
     }
@@ -155,6 +155,21 @@
       }
       return service;
     });
+
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          services
+        }
+      };
+    }
+
+    if (!persist) {
+      return new Response(null, { status: 422, statusText: 'Validation failed' });
+    }
+
     return persistServices(id);
   }
 
@@ -226,8 +241,8 @@
     <span>
       <ServiceForm_40
         service={activeService}
-        onChange={(newService) => {
-          return updateService(activeService?.id, newService);
+        onChange={(newService, persist) => {
+          return updateService(activeService?.id, newService, persist);
         }}
       />
     </span>

--- a/src/lib/components/Form/service/56_FeatureTypeForm.svelte
+++ b/src/lib/components/Form/service/56_FeatureTypeForm.svelte
@@ -81,6 +81,7 @@
         columns: []
       }
     ];
+    syncLocalFeatureTypes(featureTypes);
     activeTabId = id;
     onChange(featureTypes);
   }
@@ -92,6 +93,7 @@
       targetEl,
       async () => {
         featureTypes = featureTypes.filter((featureType) => featureType.id !== id);
+        syncLocalFeatureTypes(featureTypes);
         if (activeTabId === id) {
           activeTabId = featureTypes.length > 1 ? featureTypes[0].id : undefined;
         }
@@ -118,7 +120,60 @@
       }
       return featureType;
     });
+    syncLocalFeatureTypes(featureTypes);
     return onChange(featureTypes);
+  }
+
+  function syncLocalFeatureTypes(nextFeatureTypes: FeatureType[]) {
+    if (!formState.metadata?.isoMetadata?.services) {
+      return;
+    }
+
+    let hasMatchedService = false;
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        services: formState.metadata.isoMetadata.services.map((entry: Service) => {
+          const isTargetService =
+            entry.id === service.id ||
+            entry.serviceIdentification === service.serviceIdentification;
+
+          if (!isTargetService) {
+            return entry;
+          }
+
+          hasMatchedService = true;
+          return {
+            ...entry,
+            featureTypes: nextFeatureTypes
+          };
+        })
+      }
+    };
+
+    if (hasMatchedService) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        services: formState.metadata.isoMetadata.services.map((entry: Service) => {
+          const hasFeatureTypeFromCurrentService = entry.featureTypes?.some((ft: FeatureType) =>
+            nextFeatureTypes.some((nextFt) => nextFt.id === ft.id)
+          );
+          if (!hasFeatureTypeFromCurrentService) {
+            return entry;
+          }
+          return {
+            ...entry,
+            featureTypes: nextFeatureTypes
+          };
+        })
+      }
+    };
   }
 </script>
 

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -53,13 +53,6 @@
         hasDuplicatedValue = false;
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
-        const newValidationResult = fieldConfig?.validator(newValue, {
-          ['PARENT_VALUE']: service,
-          ['HIGHEST_ROLE']: highestRole
-        });
-        if (newValidationResult?.valid === false) {
-          return;
-        }
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -61,10 +61,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      const nextValidation = fieldConfig?.validator(newValue, {
-        ['PARENT_VALUE']: service
-      });
-      if (nextValidation?.valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -55,7 +55,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -49,7 +49,6 @@
     rows={5}
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -34,7 +34,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -51,12 +51,6 @@
       onchange={async (e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
-        const nextValidation = ValidationService.validateField(fieldConfig, newValue, {
-          HIGHEST_ROLE: highestRole,
-          PARENT_VALUE: featureType,
-          metadata
-        });
-        if (nextValidation.valid === false) return;
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -33,7 +33,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -33,7 +33,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -11,7 +11,7 @@
 
   export type ServiceTypeProps = {
     value?: ColumnInfo['type'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: ColumnInfo['type']) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -55,8 +55,9 @@
       onChange={async (newValue) => {
         const typedValue = newValue as ColumnInfo['type'];
         localValue = typedValue;
-        if (!typedValue) return;
-        if (fieldConfig?.validator(typedValue).valid === false) return;
+        if (typedValue === undefined) {
+          return;
+        }
         const response = await onChange(typedValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -36,7 +36,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;


### PR DESCRIPTION
See also [#29545](https://redmine.intranet.terrestris.de/issues/29545) and [#29500](https://redmine.intranet.terrestris.de/issues/29500).

This PR 
- adds a 98% display rule for the Services tab (99% is displayed as 98%)
- adds live synchronization for the progress bar so that required fields that have become invalid immediately lower the progress again (even without persistence)
  - invalid entries are stored locally in `formState.metadata` to ensure that the validation status and progress remain accurate
- when switching tabs, `invalidateAll` is no longer forced (in `Form.svelte`) so that local inputs are not immediately overwritten
- for geographic expansion (Berlin/Brandenburg buttons), a `tick()` was added before saving so that the values are saved correctly right away