### PR TITLE
Field updates for persisitng consistency

### DIFF
--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -18,7 +18,11 @@
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
+  let hasUnsavedLocalChange = $state(false);
   $effect(() => {
+    if (hasUnsavedLocalChange) {
+      return;
+    }
     value = valueFromData || '';
   });
 
@@ -48,6 +52,7 @@
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -57,6 +62,9 @@
   <TextAreaInput
     bind:value
     maxlength={500}
+    onchange={() => {
+      hasUnsavedLocalChange = true;
+    }}
     onblur={onBlur}
     label={t('02_DescriptionField.label')}
     explanation={t('02_DescriptionField.explanation')}

--- a/src/lib/components/Form/Field/09_CreatedField.svelte
+++ b/src/lib/components/Form/Field/09_CreatedField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.created';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   let initialized = false;
@@ -30,9 +30,32 @@
   const fieldConfig = MetadataService.getFieldConfig<string>(9);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
+  const onChange = (evt: Event) => {
+    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
+    value = inputValue;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          created: inputValue ? new Date(inputValue).toISOString() : null
+        }
+      };
+    }
+  };
+
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          created: inputValue ? new Date(inputValue).toISOString() : null
+        }
+      };
+    }
     if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
@@ -51,6 +74,7 @@
     label={t('09_CreatedField.label')}
     explanation={t('09_CreatedField.explanation')}
     {fieldConfig}
+    onchange={onChange}
     onblur={onBlur}
     {validationResult}
   />

--- a/src/lib/components/Form/Field/10_PublishedField.svelte
+++ b/src/lib/components/Form/Field/10_PublishedField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.published';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   let initialized = false;
@@ -29,18 +29,45 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(10);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+  const toIsoDate = (inputValue: string) =>
+    inputValue ? new Date(inputValue).toISOString() : null;
+  let hasUnsavedLocalChange = $state(false);
+
+  $effect(() => {
+    if (!hasUnsavedLocalChange) {
+      return;
+    }
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+    const localValue = toIsoDate(value);
+    if (formState.metadata.isoMetadata.published === localValue) {
+      return;
+    }
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        published: localValue
+      }
+    };
+  });
+
+  const onChange = (evt: Event) => {
+    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
+    value = inputValue;
+    hasUnsavedLocalChange = true;
+  };
 
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
     if (fieldConfig?.required && !inputValue) return;
     if (fieldConfig?.validator(inputValue).valid === false) return;
-    const response = await MetadataService.persistValue(
-      KEY,
-      inputValue ? new Date(inputValue).toISOString() : null
-    );
+    const response = await MetadataService.persistValue(KEY, toIsoDate(inputValue));
 
     if (response.ok) {
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -53,6 +80,7 @@
     label={t('10_PublishedField.label')}
     explanation={t('10_PublishedField.explanation')}
     {fieldConfig}
+    onchange={onChange}
     onblur={onBlur}
     {validationResult}
   />

--- a/src/lib/components/Form/Field/11_LastUpdatedField.svelte
+++ b/src/lib/components/Form/Field/11_LastUpdatedField.svelte
@@ -17,7 +17,7 @@
   const formContext = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formContext.metadata);
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY, metadata));
   let value = $state('');
   let initialized = false;
@@ -38,9 +38,32 @@
 
   let showCheckmark = $state(false);
 
+  const onChange = (evt: Event) => {
+    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
+    value = inputValue;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          modified: inputValue ? new Date(inputValue).toISOString() : null
+        }
+      };
+    }
+  };
+
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          modified: inputValue ? new Date(inputValue).toISOString() : null
+        }
+      };
+    }
     if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
@@ -58,6 +81,7 @@
     key={KEY}
     label={t('11_LastUpdatedField.label')}
     explanation={t('11_LastUpdatedField.explanation')}
+    onchange={onChange}
     onblur={onBlur}
     {fieldConfig}
     {validationResult}

--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -11,7 +11,7 @@
   const FROM_KEY = 'isoMetadata.validFrom';
   const TO_KEY = 'isoMetadata.validTo';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const startValueFromData = $derived(getValue<string>(FROM_KEY));
   let startValue = $state('');
   let startInitialized = false;
@@ -52,6 +52,16 @@
   let toValidationResult = $derived(toFieldConfig?.validator(endValue, [startValue]));
 
   const onBlur = async (key: string) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          validFrom: startValue ? new Date(startValue).toISOString() : null,
+          validTo: endValue ? new Date(endValue).toISOString() : null
+        }
+      };
+    }
     if (hasInvalidFields) {
       return;
     }
@@ -62,6 +72,25 @@
       showCheckmark = true;
     }
     invalidateAll();
+  };
+
+  const onChange = (key: string, evt: Event) => {
+    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
+    if (key === FROM_KEY) {
+      startValue = inputValue;
+    } else {
+      endValue = inputValue;
+    }
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          validFrom: startValue ? new Date(startValue).toISOString() : null,
+          validTo: endValue ? new Date(endValue).toISOString() : null
+        }
+      };
+    }
   };
 
   let hasInvalidFields = $derived.by(() => {
@@ -87,6 +116,7 @@
       <DateInput
         bind:value={startValue}
         label={t('12_ValidityRangeField.label_from')}
+        onchange={(evt) => onChange(FROM_KEY, evt)}
         onblur={() => onBlur(FROM_KEY)}
         fieldConfig={fromFieldConfig}
         validationResult={fromValidationResult}
@@ -94,6 +124,7 @@
       <DateInput
         bind:value={endValue}
         label={t('12_ValidityRangeField.label_to')}
+        onchange={(evt) => onChange(TO_KEY, evt)}
         onblur={() => onBlur(TO_KEY)}
         fieldConfig={toFieldConfig}
         validationResult={toValidationResult}

--- a/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
+++ b/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
@@ -27,7 +27,7 @@
     { key: 'unknown', label: 'unbekannt' }
   ];
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -39,6 +39,15 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue?: string) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          maintenanceFrequency: newValue as MaintenanceFrequency
+        }
+      };
+    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'technicalMetadata.deliveredCrs';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -21,6 +21,15 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
+    if (formState.metadata?.technicalMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        technicalMetadata: {
+          ...formState.metadata.technicalMetadata,
+          deliveredCrs: value
+        }
+      };
+    }
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {

--- a/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
@@ -17,7 +17,7 @@
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -29,6 +29,15 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onSelectionChange = async (newValue?: string) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          crs: newValue as string
+        }
+      };
+    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -29,10 +29,14 @@
 
   // important that this is not a state
   let previousValueAsString: string;
+  let hasUnsavedLocalChange = $state(false);
 
   const popconfirm = $derived(getPopconfirm());
 
   $effect(() => {
+    if (hasUnsavedLocalChange) {
+      return;
+    }
     // this check prevents rerendering if nothing has actually changed
     const newValueAsString = JSON.stringify(valueFromData);
     if (
@@ -105,6 +109,7 @@
     const focusedElement = evt?.relatedTarget as HTMLElement | null;
     const response = await MetadataService.persistValue(KEY, contacts);
     if (response.ok) {
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
 
@@ -146,6 +151,37 @@
       }
     );
   };
+
+  const onContactChange = () => {
+    hasUnsavedLocalChange = true;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          pointsOfContact: contacts
+        }
+      };
+    }
+  };
+
+  $effect(() => {
+    if (!hasUnsavedLocalChange || !formState.metadata?.isoMetadata) {
+      return;
+    }
+    const serverValue = JSON.stringify(formState.metadata.isoMetadata.pointsOfContact || []);
+    const localValue = JSON.stringify(contacts || []);
+    if (serverValue === localValue) {
+      return;
+    }
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        pointsOfContact: contacts
+      }
+    };
+  });
 
   let hasInvalidFields = $derived.by(() => {
     if (!fieldConfig) return false;
@@ -198,6 +234,7 @@
           <TextInput
             bind:value={contact.name}
             label={t('19_ContactsField.name')}
+            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={nameConfig}
             validationResult={nameConfig?.validator(contact.name)}
@@ -215,6 +252,7 @@
           <TextInput
             bind:value={contact.organisation}
             label={t('19_ContactsField.organisation')}
+            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={organisationConfig}
             validationResult={organisationConfig?.validator(contact.organisation)}
@@ -232,6 +270,7 @@
           <TextInput
             bind:value={contact.phone}
             label={t('19_ContactsField.phone')}
+            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={phoneConfig}
             validationResult={phoneConfig?.validator(contact.phone)}
@@ -249,6 +288,7 @@
           <TextInput
             bind:value={contact.email}
             label={t('19_ContactsField.email')}
+            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={emailConfig}
             validationResult={emailConfig?.validator(contact.email)}

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -8,6 +8,7 @@
   import FieldTools from '../FieldTools.svelte';
   import NumberInput from '../Inputs/NumberInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { MetadataUpdateService } from '$lib/services/MetadataUpdateService';
   import FormField from '@smui/form-field';
   import Radio from '@smui/radio';
 
@@ -24,24 +25,37 @@
   let selected = $state<typeof RESOLUTION_KEY | typeof SCALE_KEY>();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formState.metadata);
+  let hasUnsavedLocalChange = $state(false);
 
   // TODO: check why this is a List
   const resolutionValueFromData = $derived(getValue<number[]>(RESOLUTION_KEY)?.[0]);
   let resolutionValue = $state<number | null>(null);
-  $effect(() => {
-    if (resolutionValueFromData) {
-      resolutionValue = resolutionValueFromData;
-      selected = RESOLUTION_KEY;
-    }
-  });
-
   const scaleValueFromData = $derived(getValue<number>(SCALE_KEY));
   let scaleValue = $state<number | null>(null);
   $effect(() => {
-    if (scaleValueFromData) {
-      scaleValue = scaleValueFromData;
-      selected = SCALE_KEY;
+    if (hasUnsavedLocalChange) {
+      return;
     }
+    const hasResolution = resolutionValueFromData !== undefined && resolutionValueFromData !== null;
+    const hasScale = scaleValueFromData !== undefined && scaleValueFromData !== null;
+
+    if (hasResolution) {
+      resolutionValue = resolutionValueFromData;
+      scaleValue = hasScale ? scaleValueFromData : null;
+      selected = RESOLUTION_KEY;
+      return;
+    }
+
+    if (hasScale) {
+      scaleValue = scaleValueFromData;
+      resolutionValue = null;
+      selected = SCALE_KEY;
+      return;
+    }
+
+    resolutionValue = null;
+    scaleValue = null;
+    selected = undefined;
   });
 
   let showCheckmark = $state(false);
@@ -61,36 +75,50 @@
     !resolutionValidationResult?.valid && !scaleValidationResult?.valid
   );
 
-  const syncLocalResolutionState = () => {
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        resolutions: resolutionValue ? [resolutionValue] : null,
-        scale: scaleValue
-      }
-    };
-  };
-
   const clearAllValues = async () => {
-    scaleValue = null;
-    resolutionValue = null;
-    syncLocalResolutionState();
-    await updateResolution(null);
-    await updateScale(null);
+    hasUnsavedLocalChange = true;
+    if (selected === RESOLUTION_KEY) {
+      resolutionValue = null;
+      if (formState.metadata?.isoMetadata) {
+        formState.metadata = {
+          ...formState.metadata,
+          isoMetadata: {
+            ...formState.metadata.isoMetadata,
+            resolutions: null
+          }
+        };
+      }
+    } else if (selected === SCALE_KEY) {
+      scaleValue = null;
+      if (formState.metadata?.isoMetadata) {
+        formState.metadata = {
+          ...formState.metadata,
+          isoMetadata: {
+            ...formState.metadata.isoMetadata,
+            scale: null
+          }
+        };
+      }
+    }
   };
 
   const onBlur = async (event: FocusEvent) => {
-    syncLocalResolutionState();
+    hasUnsavedLocalChange = true;
     const target = event.target as HTMLInputElement;
     const minValue = target.getAttribute('min');
     const min = Number(minValue);
     if (!Number.isNaN(min) && Number(target.value) < min) {
       return;
+    }
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          resolutions: selected === RESOLUTION_KEY && resolutionValue ? [resolutionValue] : null,
+          scale: selected === SCALE_KEY ? scaleValue : null
+        }
+      };
     }
     const selectedValidationResult =
       selected === RESOLUTION_KEY ? resolutionValidationResult : scaleValidationResult;
@@ -98,24 +126,40 @@
       return;
     }
     if (selected === RESOLUTION_KEY) {
-      await updateResolution(resolutionValue ? [resolutionValue] : null);
+      await updateScale(null);
+      const saved = await updateResolution(resolutionValue ? [resolutionValue] : null);
+      if (saved) {
+        hasUnsavedLocalChange = false;
+      }
     } else {
-      await updateScale(scaleValue);
+      await updateResolution(null);
+      const saved = await updateScale(scaleValue);
+      if (saved) {
+        hasUnsavedLocalChange = false;
+      }
     }
   };
 
   const updateResolution = async (newValue: [number] | null) => {
-    const response = await MetadataService.persistValue(RESOLUTION_KEY, newValue);
+    const response =
+      newValue === null
+        ? await MetadataUpdateService.pushToQueue(RESOLUTION_KEY, null)
+        : await MetadataService.persistValue(RESOLUTION_KEY, newValue);
     if (response.ok) {
       showCheckmark = true;
     }
+    return response.ok;
   };
 
   const updateScale = async (newValue: number | null) => {
-    const response = await MetadataService.persistValue(SCALE_KEY, newValue);
+    const response =
+      newValue === null
+        ? await MetadataUpdateService.pushToQueue(SCALE_KEY, null)
+        : await MetadataService.persistValue(SCALE_KEY, newValue);
     if (response.ok) {
       showCheckmark = true;
     }
+    return response.ok;
   };
 </script>
 

--- a/src/lib/components/Form/Field/29_PreviewField.svelte
+++ b/src/lib/components/Form/Field/29_PreviewField.svelte
@@ -18,7 +18,11 @@
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
+  let hasUnsavedLocalChange = $state(false);
   $effect(() => {
+    if (hasUnsavedLocalChange) {
+      return;
+    }
     value = valueFromData || '';
   });
 
@@ -48,6 +52,7 @@
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -56,6 +61,9 @@
 <div class="preview-field">
   <TextInput
     bind:value
+    onchange={() => {
+      hasUnsavedLocalChange = true;
+    }}
     label={t('29_PreviewField.label')}
     explanation={t('29_PreviewField.explanation')}
     {fieldConfig}

--- a/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
+++ b/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
@@ -14,7 +14,7 @@
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string[]>(KEY));
   let value = $state<string[]>();
   $effect(() => {
@@ -26,6 +26,15 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onChange = async (newValue?: string[]) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          spatialRepresentationTypes: newValue
+        }
+      };
+    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -740,7 +740,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     profileId: 45,
     key: 'isoMetadata.services.workspace',
     collectionKey: 'isoMetadata.services',
-    extraParams: ['PARENT_VALUE', 'HIGHEST_ROLE'],
+    extraParams: ['PARENT_VALUE', 'HIGHEST_ROLE', 'isoMetadata.services'],
     validator: (workspace: Service['workspace'], extraParams) => {
       const highestRole = extraParams?.['HIGHEST_ROLE'] as string;
       const required = ['MdeEditor', 'MdeAdministrator'].includes(highestRole);
@@ -753,6 +753,17 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
           valid: false,
           helpText:
             'Bitte geben Sie einen gültigen Workspace an. Nur Buchstaben, Zahlen und Unterstriche sind erlaubt.'
+        };
+      }
+      const service = extraParams?.['PARENT_VALUE'] as Service;
+      const services = (extraParams?.['isoMetadata.services'] || []) as Service[];
+      const hasDuplicateWorkspace = services.some(
+        (entry) => entry.id !== service?.id && entry.workspace === workspace
+      );
+      if (hasDuplicateWorkspace) {
+        return {
+          valid: false,
+          helpText: 'Der angegebene Identifikator ist bereits vergeben.'
         };
       }
       return { valid };

--- a/src/lib/components/Form/Inputs/DateInput.svelte
+++ b/src/lib/components/Form/Inputs/DateInput.svelte
@@ -68,6 +68,10 @@
     id={key}
     name={key}
     bind:value
+    oninput={(evt) => {
+      value = (evt.currentTarget as HTMLInputElement).value;
+      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLInputElement });
+    }}
     onblur={(evt) => {
       value = (evt.currentTarget as HTMLInputElement).value;
       onblur?.(evt);

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -22,6 +22,8 @@
   import { logger } from 'loggisch';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
+  import { validateFeatureTypes } from './validation';
+  import { ValidationService } from '$lib/services/ValidationService';
 
   const t = $derived(page.data.t);
 
@@ -74,9 +76,10 @@
     return onChange(service, true);
   }
 
-  async function set<K extends keyof Service>(key: K, value: Service[K]) {
+  async function set<K extends keyof Service>(key: K, value: Service[K], persist?: boolean) {
     service = setNestedValue(service, key, value);
-    const response = await onChange(service, shouldPersistFieldValue(key, value));
+    const shouldPersist = persist ?? shouldPersistFieldValue(key, value);
+    const response = await onChange(service, shouldPersist);
     if (response.ok) {
       if (key === 'serviceType') {
         onServiceTypeChange(value as ServiceType);
@@ -100,9 +103,10 @@
   const shouldPersistFieldValue = <K extends keyof Service>(key: K, value: Service[K]) => {
     if (key === 'workspace') {
       const fieldConfig = MetadataService.getFieldConfig<string>(45);
-      return fieldConfig?.validator(value as Service['workspace'], {
+      return ValidationService.validateField(fieldConfig, value as Service['workspace'], {
         ['PARENT_VALUE']: service,
-        ['HIGHEST_ROLE']: highestRole
+        ['HIGHEST_ROLE']: highestRole,
+        metadata
       }).valid;
     }
     if (key === 'preview') {
@@ -121,9 +125,16 @@
     }
     if (key === 'featureTypes') {
       const fieldConfig = MetadataService.getFieldConfig<Service['featureTypes']>(56);
-      return fieldConfig?.validator(value as Service['featureTypes'], {
+      const featureTypes = value as Service['featureTypes'];
+      const hasValidFeatureTypeCollection = fieldConfig?.validator(featureTypes, {
         ['PARENT_VALUE']: service
       }).valid;
+      const hasInvalidFeatureTypes =
+        validateFeatureTypes(featureTypes || [], {
+          metadata,
+          HIGHEST_ROLE: highestRole
+        }).size > 0;
+      return hasValidFeatureTypeCollection && !hasInvalidFeatureTypes;
     }
     if (key === 'serviceType') {
       const fieldConfig = MetadataService.getFieldConfig<ServiceType>(58);
@@ -133,9 +144,26 @@
     return true;
   };
 
-  async function onLayersChange(layers: Layer[]) {
+  async function onLayersChange(layers: Layer[], persist = true) {
     const serviceIdentification = service?.serviceIdentification;
     if (!serviceIdentification) return Promise.reject('Service identification is missing');
+
+    if (formContext.metadata) {
+      formContext.metadata = {
+        ...formContext.metadata,
+        clientMetadata: {
+          ...formContext.metadata.clientMetadata,
+          layers: {
+            ...(formContext.metadata.clientMetadata?.layers || {}),
+            [serviceIdentification]: layers
+          }
+        }
+      };
+    }
+
+    if (!persist) {
+      return new Response(null, { status: 422, statusText: 'Validation failed' });
+    }
 
     const response = await fetch(
       `${page.url.origin}${page.url.pathname}/updateLayers/${serviceIdentification}`,
@@ -152,23 +180,27 @@
 
     if (!response.ok) {
       toast.error(t('serviceform.layer_update_error', { statusText: response.statusText }));
+    } else {
+      await invalidateAll();
     }
-    invalidateAll();
     return response;
   }
 </script>
 
 <div class="service-form">
   <ServiceType_58 value={service.serviceType} onChange={onServiceTypeChange} />
-  <ServiceTitle_59 value={service.title} onChange={(title) => set('title', title)} />
+  <ServiceTitle_59
+    value={service.title}
+    onChange={(title, persist) => set('title', title, persist)}
+  />
   <ServiceShortDescription_60
     value={service.shortDescription}
-    onChange={(shortDescription) => set('shortDescription', shortDescription)}
+    onChange={(shortDescription, persist) => set('shortDescription', shortDescription, persist)}
   />
   <ServiceWorkspace_45
     value={service.workspace}
     {service}
-    onChange={(workspace) => set('workspace', workspace)}
+    onChange={(workspace, persist) => set('workspace', workspace, persist)}
   />
   <ServicePreview_46
     value={service.preview}
@@ -186,7 +218,7 @@
     <FeatureTypeForm_56
       {service}
       value={service.featureTypes}
-      onChange={(featureTypes) => set('featureTypes', featureTypes)}
+      onChange={(featureTypes, persist) => set('featureTypes', featureTypes, persist)}
     />
   {/if}
 </div>

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -11,6 +11,7 @@
   import { getPopconfirm } from '$lib/context/PopConfirmContext.svelte';
   import { validateService } from './validation';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { ValidationService } from '$lib/services/ValidationService';
 
   const t = $derived(page.data.t);
 
@@ -31,6 +32,7 @@
 
   let initialServices = getValue<Service[]>(KEY);
   let services = $state<Service[]>([]);
+  let lastPersistedServices = $state<Service[]>(initialServices || []);
   let tabs = $derived<Tab[]>(
     services.map((service) => {
       const mappingService = service.serviceType === 'WMS' || service.serviceType === 'WMTS';
@@ -74,14 +76,42 @@
 
   $effect(() => {
     services = initialServices || [];
+    lastPersistedServices = initialServices || [];
     activeTab = initialServices?.length ? initialServices[0].id : '';
   });
 
   let visibleCheckmarks = $state<Record<string, boolean>>({});
 
+  const isWorkspacePersistable = (service: Service, serviceList: Service[]) => {
+    const fieldConfig = MetadataService.getFieldConfig<string>(45);
+    const validation = ValidationService.validateField(fieldConfig, service.workspace, {
+      metadata,
+      PARENT_VALUE: service,
+      HIGHEST_ROLE: highestRole
+    });
+    if (validation.valid === false) return false;
+
+    return !serviceList.some(
+      (entry) => entry.id !== service.id && entry.workspace === service.workspace
+    );
+  };
+
+  const getPersistableServices = (serviceList: Service[]) => {
+    return serviceList.map((service) => {
+      if (isWorkspacePersistable(service, serviceList)) {
+        return service;
+      }
+
+      const lastPersisted = lastPersistedServices.find((entry) => entry.id === service.id);
+      return lastPersisted ? { ...service, workspace: lastPersisted.workspace } : service;
+    });
+  };
+
   const persistServices = async (id: string) => {
-    const response = await MetadataService.persistValue(KEY, services);
+    const persistableServices = getPersistableServices(services);
+    const response = await MetadataService.persistValue(KEY, persistableServices);
     if (response.ok) {
+      lastPersistedServices = persistableServices;
       visibleCheckmarks[id] = true;
     }
     return response;
@@ -242,7 +272,7 @@
       <ServiceForm_40
         service={activeService}
         onChange={(newService, persist) => {
-          return updateService(activeService?.id, newService, persist);
+          return updateService(newService?.id, newService, persist);
         }}
       />
     </span>

--- a/src/lib/components/Form/service/48_LayersForm.svelte
+++ b/src/lib/components/Form/service/48_LayersForm.svelte
@@ -28,7 +28,7 @@
   export type LayersFormProps = {
     value?: Layer[];
     service?: Service;
-    onChange: (layers: Layer[]) => Promise<Response>;
+    onChange: (layers: Layer[], persist?: boolean) => Promise<Response>;
   };
 
   let { value: initialLayers, service, onChange }: LayersFormProps = $props();
@@ -84,6 +84,7 @@
         styleName: ''
       }
     ];
+    syncLocalLayers(layers);
     activeTabId = id;
     onChange(layers);
   }
@@ -95,6 +96,7 @@
       targetEl,
       async () => {
         layers = layers.filter((layer) => layer.id !== layerId);
+        syncLocalLayers(layers);
         if (activeTabId === layerId) {
           activeTabId = layers.length > 0 ? layers[layers.length - 1]?.id : undefined;
         }
@@ -111,7 +113,7 @@
     );
   }
 
-  function set(key: string, value: Layer[keyof Layer]) {
+  function set(key: string, value: Layer[keyof Layer], persist?: boolean) {
     layers = layers.map((layer) => {
       if (layer.id === activeTabId) {
         return {
@@ -121,7 +123,25 @@
       }
       return layer;
     });
-    return onChange(layers);
+    syncLocalLayers(layers);
+    return onChange(layers, persist);
+  }
+
+  function syncLocalLayers(nextLayers: Layer[]) {
+    if (!formState.metadata || !serviceId) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      clientMetadata: {
+        ...formState.metadata.clientMetadata,
+        layers: {
+          ...(formState.metadata.clientMetadata?.layers || {}),
+          [serviceId]: nextLayers
+        }
+      }
+    };
   }
 </script>
 
@@ -176,15 +196,21 @@
     </nav>
     <div class="content">
       {#if activeTabId && activeLayer}
-        <LayerTitle_49 value={activeLayer?.title} onChange={(title) => set('title', title)} />
-        <LayerName_50 value={activeLayer?.name} onChange={(name) => set('name', name)} />
+        <LayerTitle_49
+          value={activeLayer?.title}
+          onChange={(title, persist) => set('title', title, persist)}
+        />
+        <LayerName_50
+          value={activeLayer?.name}
+          onChange={(name, persist) => set('name', name, persist)}
+        />
         <LayerStyleTitle_52
           value={activeLayer?.styleTitle}
-          onChange={(styleTitle) => set('styleTitle', styleTitle)}
+          onChange={(styleTitle, persist) => set('styleTitle', styleTitle, persist)}
         />
         <LayerStyleName_51
           value={activeLayer?.styleName}
-          onChange={(styleName) => set('styleName', styleName)}
+          onChange={(styleName, persist) => set('styleName', styleName, persist)}
         />
         <LayerLegendImage_53
           value={activeLayer?.legendImage}
@@ -192,7 +218,8 @@
         />
         <LayerDescription_54
           value={activeLayer?.shortDescription}
-          onChange={(shortDescription) => set('shortDescription', shortDescription)}
+          onChange={(shortDescription, persist) =>
+            set('shortDescription', shortDescription, persist)}
         />
         <LayerDatasource_55
           value={activeLayer?.datasource}

--- a/src/lib/components/Form/service/56_FeatureTypeForm.svelte
+++ b/src/lib/components/Form/service/56_FeatureTypeForm.svelte
@@ -24,7 +24,7 @@
   export type FeatureTypeFormProps = {
     value?: FeatureType[];
     service: Service;
-    onChange: (featureTypes: FeatureType[]) => Promise<Response>;
+    onChange: (featureTypes: FeatureType[], persist?: boolean) => Promise<Response>;
   };
 
   let { value: initialFeatureTypes, onChange, service }: FeatureTypeFormProps = $props();
@@ -110,7 +110,7 @@
     );
   }
 
-  function set(key: string, value: FeatureType[keyof FeatureType]) {
+  function set(key: string, value: FeatureType[keyof FeatureType], persist?: boolean) {
     featureTypes = featureTypes.map((featureType) => {
       if (featureType.id === activeTabId) {
         return {
@@ -121,7 +121,7 @@
       return featureType;
     });
     syncLocalFeatureTypes(featureTypes);
-    return onChange(featureTypes);
+    return onChange(featureTypes, persist);
   }
 
   function syncLocalFeatureTypes(nextFeatureTypes: FeatureType[]) {
@@ -232,21 +232,22 @@
       {#if activeTabId && activeFeatureType}
         <FeatureTypeTitle_61
           value={activeFeatureType?.title}
-          onChange={(title) => set('title', title)}
+          onChange={(title, persist) => set('title', title, persist)}
         />
         <FeatureTypeName_62
           featureType={activeFeatureType}
           value={activeFeatureType?.name}
-          onChange={(name) => set('name', name)}
+          onChange={(name, persist) => set('name', name, persist)}
         />
         <FeatureTypeDescription_69
           value={activeFeatureType?.shortDescription}
-          onChange={(shortDescription) => set('shortDescription', shortDescription)}
+          onChange={(shortDescription, persist) =>
+            set('shortDescription', shortDescription, persist)}
         />
         <ColumnsForm_63
           featureType={activeFeatureType}
           value={activeFeatureType?.columns}
-          onChange={(columns) => set('columns', columns)}
+          onChange={(columns, persist) => set('columns', columns, persist)}
         />
       {/if}
     </div>

--- a/src/lib/components/Form/service/63_ColumnsForm.svelte
+++ b/src/lib/components/Form/service/63_ColumnsForm.svelte
@@ -23,7 +23,7 @@
   export type ColumnsFormProps = {
     featureType: FeatureType;
     value?: ColumnInfo[];
-    onChange: (columns: ColumnInfo[]) => Promise<Response>;
+    onChange: (columns: ColumnInfo[], persist?: boolean) => Promise<Response>;
   };
 
   let { value: initialColumns, onChange, featureType }: ColumnsFormProps = $props();
@@ -101,7 +101,7 @@
     );
   }
 
-  function set(key: string, value: ColumnInfo[keyof ColumnInfo]) {
+  function set(key: string, value: ColumnInfo[keyof ColumnInfo], persist?: boolean) {
     columns = columns.map((column) => {
       if (column.id === activeTabId) {
         return {
@@ -111,7 +111,7 @@
       }
       return column;
     });
-    return onChange(columns);
+    return onChange(columns, persist);
   }
 </script>
 
@@ -166,9 +166,18 @@
     </nav>
     <div class="content">
       {#if activeTabId && activeColumn}
-        <AttributeName_64 value={activeColumn?.name} onChange={(name) => set('name', name)} />
-        <AttributeAlias_65 value={activeColumn?.alias} onChange={(alias) => set('alias', alias)} />
-        <AttributeDatatype_66 value={activeColumn?.type} onChange={(type) => set('type', type)} />
+        <AttributeName_64
+          value={activeColumn?.name}
+          onChange={(name, persist) => set('name', name, persist)}
+        />
+        <AttributeAlias_65
+          value={activeColumn?.alias}
+          onChange={(alias, persist) => set('alias', alias, persist)}
+        />
+        <AttributeDatatype_66
+          value={activeColumn?.type}
+          onChange={(type, persist) => set('type', type, persist)}
+        />
       {/if}
     </div>
   </fieldset>

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -2,6 +2,7 @@
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import type { Service } from '$lib/models/metadata';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { getFormContext } from '$lib/context/FormContext.svelte';
   import { getHighestRole } from '$lib/util';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
@@ -11,7 +12,7 @@
   export type ComponentProps = {
     value?: Service['workspace'];
     service: Service;
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, service, onChange }: ComponentProps = $props();
@@ -22,10 +23,22 @@
 
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
+  const { getValue } = getFormContext();
 
   const HELP_KEY = 'isoMetadata.services.workspace';
   const fieldConfig = MetadataService.getFieldConfig(45);
   let hasDuplicatedValue = $state<boolean>(false);
+  const isDuplicateServiceId = (nextValue: string) => {
+    const allServices = getValue<Service[]>('isoMetadata.services') || [];
+    return allServices.some((entry) => entry.id !== service.id && entry.workspace === nextValue);
+  };
+  const isInvalidWorkspace = (nextValue: string) => {
+    const nextValidation = fieldConfig?.validator(nextValue, {
+      ['PARENT_VALUE']: service,
+      ['HIGHEST_ROLE']: highestRole
+    });
+    return hasDuplicatedValue || nextValidation?.valid === false;
+  };
   const validationResult = $derived.by(() => {
     if (hasDuplicatedValue) {
       return {
@@ -38,6 +51,9 @@
       ['HIGHEST_ROLE']: highestRole
     });
   });
+  $effect(() => {
+    hasDuplicatedValue = isDuplicateServiceId(localValue);
+  });
   let showCheckmark = $state(false);
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
 </script>
@@ -49,15 +65,23 @@
       value={localValue}
       {fieldConfig}
       {validationResult}
-      onchange={async (e: Event) => {
-        hasDuplicatedValue = false;
+      onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+        hasDuplicatedValue = isDuplicateServiceId(newValue);
+        void onChange(newValue, false);
+      }}
+      onblur={async (e: Event) => {
+        const newValue = (e.target as HTMLInputElement).value;
+        hasDuplicatedValue = isDuplicateServiceId(newValue);
+        if (isInvalidWorkspace(newValue)) return;
+
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;
         } else if (response.status === 409) {
           hasDuplicatedValue = true;
+          void onChange(value || '', false);
         }
       }}
     />

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -13,7 +13,7 @@
   export type ComponentProps = {
     value?: Service['preview'];
     service: Service;
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, service, onChange }: ComponentProps = $props();
@@ -58,9 +58,13 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/49_LayerTitle.svelte
+++ b/src/lib/components/Form/service/Field/49_LayerTitle.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: Layer['title'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -31,9 +31,13 @@
     {fieldConfig}
     {validationResult}
     maxlength={250}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/50_LayerName.svelte
+++ b/src/lib/components/Form/service/Field/50_LayerName.svelte
@@ -10,7 +10,7 @@
 
   export type ComponentProps = {
     value?: Layer['name'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -32,9 +32,14 @@
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
   let showCheckmark = $state(false);
 
-  const onChangeInternal = async (e: Event) => {
+  const onChangeInternal = (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
     localValue = newValue;
+    void onChange(newValue, false);
+  };
+
+  const onBlurInternal = async (e: Event) => {
+    const newValue = (e.target as HTMLInputElement).value;
     if (
       fieldConfig?.validator(newValue, {
         ['HIGHEST_ROLE']: highestRole
@@ -58,6 +63,7 @@
       {fieldConfig}
       {validationResult}
       onchange={onChangeInternal}
+      onblur={onBlurInternal}
     />
     <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>

--- a/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
+++ b/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
@@ -10,7 +10,7 @@
 
   export type ComponentProps = {
     value?: Layer['styleName'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -33,9 +33,14 @@
   );
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
 
-  const onChangeInternal = async (e: Event) => {
+  const onChangeInternal = (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
     localValue = newValue;
+    void onChange(newValue, false);
+  };
+
+  const onBlurInternal = async (e: Event) => {
+    const newValue = (e.target as HTMLInputElement).value;
     if (
       fieldConfig?.validator(newValue, {
         ['HIGHEST_ROLE']: highestRole
@@ -59,6 +64,7 @@
       {fieldConfig}
       {validationResult}
       onchange={onChangeInternal}
+      onblur={onBlurInternal}
     />
     <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>

--- a/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
+++ b/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
@@ -11,7 +11,7 @@
 
   export type ComponentProps = {
     value?: Layer['styleTitle'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   const PROFILE_KEY = 'isoMetadata.metadataProfile';
@@ -51,9 +51,13 @@
       maxlength={250}
       {fieldConfig}
       {validationResult}
-      onchange={async (e: Event) => {
+      onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+        void onChange(newValue, false);
+      }}
+      onblur={async (e: Event) => {
+        const newValue = (e.target as HTMLInputElement).value;
         if (
           fieldConfig?.validator(newValue, {
             HIGHEST_ROLE: highestRole,

--- a/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
@@ -31,9 +31,12 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/54_LayerDescription.svelte
+++ b/src/lib/components/Form/service/Field/54_LayerDescription.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: Layer['shortDescription'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -32,9 +32,13 @@
     maxlength={500}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
+++ b/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
@@ -31,9 +31,12 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -12,7 +12,7 @@
 
   export type ServiceTypeProps = {
     value: Service['title'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -52,9 +52,13 @@
     {fieldConfig}
     {validationResult}
     maxlength={250}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -12,7 +12,7 @@
 
   export type ServiceTypeProps = {
     value: Service['shortDescription'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value = $bindable(), onChange }: ServiceTypeProps = $props();
@@ -47,7 +47,12 @@
     {fieldConfig}
     {validationResult}
     rows={5}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
+      value = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: FeatureType['title'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -31,9 +31,13 @@
     maxlength={100}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -14,7 +14,7 @@
   export type ComponentProps = {
     value?: FeatureType['name'];
     featureType: FeatureType;
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, featureType, onChange }: ComponentProps = $props();
@@ -48,9 +48,13 @@
       maxlength={100}
       {fieldConfig}
       {validationResult}
-      onchange={async (e: Event) => {
+      onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+        void onChange(newValue, false);
+      }}
+      onblur={async (e: Event) => {
+        const newValue = (e.target as HTMLInputElement).value;
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: ColumnInfo['name'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -30,9 +30,13 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: ColumnInfo['alias'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -30,9 +30,13 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -11,7 +11,7 @@
 
   export type ServiceTypeProps = {
     value?: ColumnInfo['type'];
-    onChange: (newValue: ColumnInfo['type']) => Promise<Response>;
+    onChange: (newValue: ColumnInfo['type'], persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -55,10 +55,7 @@
       onChange={async (newValue) => {
         const typedValue = newValue as ColumnInfo['type'];
         localValue = typedValue;
-        if (typedValue === undefined) {
-          return;
-        }
-        const response = await onChange(typedValue);
+        const response = await onChange(typedValue, typedValue !== undefined);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
+++ b/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
@@ -37,9 +37,12 @@
       value={localValue}
       {fieldConfig}
       {validationResult}
-      onchange={async (e: Event) => {
+      onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+      }}
+      onblur={async (e: Event) => {
+        const newValue = (e.target as HTMLInputElement).value;
         if (fieldConfig?.validator(newValue).valid === false) return;
         const response = await onChange(newValue);
         if (response.ok) {

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -9,7 +9,7 @@
 
   export type ComponentProps = {
     value?: FeatureType['shortDescription'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -33,9 +33,13 @@
     maxlength={500}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/validation.ts
+++ b/src/lib/components/Form/service/validation.ts
@@ -189,6 +189,10 @@ export function validateService(
   ];
 
   const fieldsValid = validateFields(validations);
+  const allServices = (context?.metadata?.isoMetadata?.services || []) as Service[];
+  const hasDuplicateWorkspace =
+    !!service?.workspace &&
+    allServices.some((entry) => entry.id !== service.id && entry.workspace === service.workspace);
   const featureTypesRequired = service.serviceType === 'WFS';
   const layersRequired = ['WMS', 'WMTS'].includes(service?.serviceType || '');
   let hasInvalidLayersFlag = false;
@@ -202,7 +206,7 @@ export function validateService(
   }
 
   return {
-    hasInvalidFields: !fieldsValid,
+    hasInvalidFields: !fieldsValid || hasDuplicateWorkspace,
     hasInvalidLayers: hasInvalidLayersFlag,
     hasInvalidFeatureTypes: hasInvalidFeatureTypesFlag
   };


### PR DESCRIPTION
See also [#29500](https://redmine.intranet.terrestris.de/issues/29500?journals=all#note-350456).

This PR is a follow up to #282 and fixes a few consistency issues when saving content that failed validation. Additionally, the fields have been updated so that the progress bar now reflects the form's actual status.