### PR TITLE
Fix field validations

### DIFF
--- a/src/lib/components/Form/Field/04_PrivacyField.svelte
+++ b/src/lib/components/Form/Field/04_PrivacyField.svelte
@@ -4,6 +4,7 @@
   import RadioInput from '../Inputs/RadioInput.svelte';
   import type { ValidationResult } from '../FieldsConfig';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { MetadataUpdateService } from '$lib/services/MetadataUpdateService';
   import type { Option } from '$lib/models/form';
   import { toast } from 'svelte-french-toast';
   import { page } from '$app/state';
@@ -30,7 +31,7 @@
       showCheckmark = true;
 
       // delete terms of use value if privacy is changed
-      await MetadataService.persistValue(TERMS_OF_USE_KEY, null);
+      await MetadataUpdateService.pushToQueue(TERMS_OF_USE_KEY, null);
     }
   };
 

--- a/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
+++ b/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
@@ -4,14 +4,13 @@
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import { page } from '$app/state';
-  import { ValidationService } from '$lib/services/ValidationService';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.termsOfUseSource';
   const TERMS_OF_USE_KEY = 'isoMetadata.termsOfUseId';
   const PRIVACY_KEY = 'isoMetadata.privacy';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   const termsOfUseId = $derived(getValue<number>(TERMS_OF_USE_KEY));
   const privacy = $derived(getValue<string>(PRIVACY_KEY));
@@ -21,9 +20,19 @@
     value = valueFromData || '';
   });
 
+  $effect(() => {
+    if (!formState.metadata?.isoMetadata) return;
+    formState.metadata.isoMetadata.termsOfUseSource = value;
+  });
+
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(26);
-  let validationResult = $derived(ValidationService.validateField(fieldConfig, value));
+  let validationResult = $derived(
+    fieldConfig?.validator(value, {
+      'isoMetadata.termsOfUseId': termsOfUseId,
+      'isoMetadata.privacy': privacy
+    })
+  );
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -526,10 +526,11 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
   {
     profileId: 26,
     key: 'isoMetadata.termsOfUseSource',
-    extraParams: ['isoMetadata.termsOfUseId'],
+    extraParams: ['isoMetadata.termsOfUseId', 'isoMetadata.privacy'],
     validator: (val, extraParams) => {
       const termsOfUseId = extraParams?.['isoMetadata.termsOfUseId'];
-      const isRequired = termsOfUseId !== 1;
+      const privacy = extraParams?.['isoMetadata.privacy'];
+      const isRequired = privacy === 'NONE' && !!termsOfUseId && termsOfUseId !== 1;
       if (isRequired && !isDefined(val)) {
         return {
           valid: false,

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -758,7 +758,10 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       const service = extraParams?.['PARENT_VALUE'] as Service;
       const services = (extraParams?.['isoMetadata.services'] || []) as Service[];
       const hasDuplicateWorkspace = services.some(
-        (entry) => entry.id !== service?.id && entry.workspace === workspace
+        (entry) =>
+          entry.id !== service?.id &&
+          entry.workspace === workspace &&
+          entry.serviceType === service?.serviceType
       );
       if (hasDuplicateWorkspace) {
         return {

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -92,7 +92,10 @@
     if (validation.valid === false) return false;
 
     return !serviceList.some(
-      (entry) => entry.id !== service.id && entry.workspace === service.workspace
+      (entry) =>
+        entry.id !== service.id &&
+        entry.workspace === service.workspace &&
+        entry.serviceType === service.serviceType
     );
   };
 

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -30,7 +30,12 @@
   let hasDuplicatedValue = $state<boolean>(false);
   const isDuplicateServiceId = (nextValue: string) => {
     const allServices = getValue<Service[]>('isoMetadata.services') || [];
-    return allServices.some((entry) => entry.id !== service.id && entry.workspace === nextValue);
+    return allServices.some(
+      (entry) =>
+        entry.id !== service.id &&
+        entry.workspace === nextValue &&
+        entry.serviceType === service.serviceType
+    );
   };
   const isInvalidWorkspace = (nextValue: string) => {
     const nextValidation = fieldConfig?.validator(nextValue, {

--- a/src/lib/components/Form/service/validation.ts
+++ b/src/lib/components/Form/service/validation.ts
@@ -192,7 +192,12 @@ export function validateService(
   const allServices = (context?.metadata?.isoMetadata?.services || []) as Service[];
   const hasDuplicateWorkspace =
     !!service?.workspace &&
-    allServices.some((entry) => entry.id !== service.id && entry.workspace === service.workspace);
+    allServices.some(
+      (entry) =>
+        entry.id !== service.id &&
+        entry.workspace === service.workspace &&
+        entry.serviceType === service.serviceType
+    );
   const featureTypesRequired = service.serviceType === 'WFS';
   const layersRequired = ['WMS', 'WMTS'].includes(service?.serviceType || '');
   let hasInvalidLayersFlag = false;

--- a/src/lib/services/ValidationService.ts
+++ b/src/lib/services/ValidationService.ts
@@ -246,6 +246,9 @@ export class ValidationService {
                 // No service found for this layer, skip it
                 continue;
               }
+              if (layerService.id !== v.id) {
+                continue;
+              }
 
               const fieldPath = `clientMetadata.layers['${serviceId}']`;
               // handle the 'clientMetadata.layers' collection itself


### PR DESCRIPTION
See also [#29500](https://redmine.intranet.terrestris.de/issues/29500?journals=all#note-351437).

This PR is another follow-up to #283 and #282 and addresses validation errors and data consistency issues:

- the validation rule where the uniqueness of a service ID is checked in combination with the service type, rather than globally will be restored

- a bug where the "Source NB" field remained a required background dependency even after being hidden by privacy setting changes will be fixed

- "Terms of Use" field resets correctly via the `MetadataUpdateService` when privacy settings are modified