### PR TITLE
fix: improve service layer persistence during validation updates

### DIFF
--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -77,6 +77,11 @@
   }
 
   async function set<K extends keyof Service>(key: K, value: Service[K], persist?: boolean) {
+    const serviceIdentification = service?.serviceIdentification;
+    const localLayersBeforePersist = serviceIdentification
+      ? formContext.metadata?.clientMetadata?.layers?.[serviceIdentification]
+      : undefined;
+
     service = setNestedValue(service, key, value);
     const shouldPersist = persist ?? shouldPersistFieldValue(key, value);
     const response = await onChange(service, shouldPersist);
@@ -96,6 +101,25 @@
         }
       }
       await invalidateAll();
+      // keep local layer edits (including invalid, not persisted values) when only service fields change
+      if (
+        key !== 'serviceType' &&
+        serviceIdentification &&
+        (service.serviceType === 'WMS' || service.serviceType === 'WMTS') &&
+        localLayersBeforePersist &&
+        formContext.metadata
+      ) {
+        formContext.metadata = {
+          ...formContext.metadata,
+          clientMetadata: {
+            ...formContext.metadata.clientMetadata,
+            layers: {
+              ...(formContext.metadata.clientMetadata?.layers || {}),
+              [serviceIdentification]: localLayersBeforePersist
+            }
+          }
+        };
+      }
     }
     return response;
   }

--- a/src/lib/services/ValidationService.ts
+++ b/src/lib/services/ValidationService.ts
@@ -293,7 +293,10 @@ export class ValidationService {
         const parentConfig = FieldConfigs.find(({ key }) => key === field.collectionKey);
         if (!parentConfig) return;
 
-        const parentCollection = MetadataService.getAllValues(parentConfig.key, metadata!) as any[];
+        const parentCollection =
+          field.collectionKey === 'clientMetadata.layers'
+            ? (MetadataService.getValue<Service[]>('isoMetadata.services', metadata!) as any[])
+            : (MetadataService.getAllValues(parentConfig.key, metadata!) as any[]);
 
         // If parent collection is empty or not an array, skip validation
         if (!Array.isArray(parentCollection) || parentCollection.length === 0) {


### PR DESCRIPTION
See also [#29500](https://redmine.intranet.terrestris.de/issues/29500?journals=all#note-351554).

This PR fixes two service-form validation/progress inconsistencies for WMS/WMTS:

- progress fix for WMTS layer required fields
- preserve local invalid layer input on unrelated service updates

Services progress now drops correctly when required WMTS layer fields become invalid and
editing other service fields no longer overwrites in-progress invalid layer input for WMS/WMTS.