### PR TITLE
Revert features

### DIFF
--- a/src/lib/components/Form/Field/01_TitleField.svelte
+++ b/src/lib/components/Form/Field/01_TitleField.svelte
@@ -20,7 +20,6 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onBlur = async () => {
-    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/01_TitleField.svelte
+++ b/src/lib/components/Form/Field/01_TitleField.svelte
@@ -1,20 +1,14 @@
 <script lang="ts">
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
-  import {
-    FORMSTATE_CONTEXT,
-    getFormContext,
-    type FormState
-  } from '$lib/context/FormContext.svelte';
+  import { getFormContext } from '$lib/context/FormContext.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import { page } from '$app/state';
-  import { getContext } from 'svelte';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.title';
 
   const formContext = $derived(getFormContext());
-  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(formContext.getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -24,24 +18,6 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(1);
   let validationResult = $derived(fieldConfig?.validator(value));
-
-  $effect(() => {
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-
-    if (formState.metadata.isoMetadata.title === value) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        title: value
-      }
-    };
-  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -18,11 +18,7 @@
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
-  let hasUnsavedLocalChange = $state(false);
   $effect(() => {
-    if (hasUnsavedLocalChange) {
-      return;
-    }
     value = valueFromData || '';
   });
 
@@ -52,7 +48,6 @@
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
-      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -62,9 +57,6 @@
   <TextAreaInput
     bind:value
     maxlength={500}
-    onchange={() => {
-      hasUnsavedLocalChange = true;
-    }}
     onblur={onBlur}
     label={t('02_DescriptionField.label')}
     explanation={t('02_DescriptionField.explanation')}

--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -1,21 +1,15 @@
 <script lang="ts">
   import type { ValidationResult } from '../FieldsConfig';
   import FieldTools from '../FieldTools.svelte';
-  import {
-    FORMSTATE_CONTEXT,
-    getFormContext,
-    type FormState
-  } from '$lib/context/FormContext.svelte';
+  import { getFormContext } from '$lib/context/FormContext.svelte';
   import TextAreaInput from '../Inputs/TextAreaInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import { page } from '$app/state';
-  import { getContext } from 'svelte';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.description';
 
   const { getValue } = getFormContext();
-  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -25,24 +19,6 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(2);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
-
-  $effect(() => {
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-
-    if (formState.metadata.isoMetadata.description === value) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        description: value
-      }
-    };
-  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -21,7 +21,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
-    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/04_PrivacyField.svelte
+++ b/src/lib/components/Form/Field/04_PrivacyField.svelte
@@ -24,7 +24,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue: string) => {
-    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/04_PrivacyField.svelte
+++ b/src/lib/components/Form/Field/04_PrivacyField.svelte
@@ -4,7 +4,6 @@
   import RadioInput from '../Inputs/RadioInput.svelte';
   import type { ValidationResult } from '../FieldsConfig';
   import { MetadataService } from '$lib/services/MetadataService';
-  import { MetadataUpdateService } from '$lib/services/MetadataUpdateService';
   import type { Option } from '$lib/models/form';
   import { toast } from 'svelte-french-toast';
   import { page } from '$app/state';
@@ -31,7 +30,7 @@
       showCheckmark = true;
 
       // delete terms of use value if privacy is changed
-      await MetadataUpdateService.pushToQueue(TERMS_OF_USE_KEY, null);
+      await MetadataService.persistValue(TERMS_OF_USE_KEY, null);
     }
   };
 

--- a/src/lib/components/Form/Field/05_MetadataProfileField.svelte
+++ b/src/lib/components/Form/Field/05_MetadataProfileField.svelte
@@ -39,7 +39,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue?: string) => {
-    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
+++ b/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
@@ -47,13 +47,6 @@
   };
 
   const onSelectionChange = async (newSelection?: string[]) => {
-    if (
-      categoryFieldConfig?.validator(newSelection, {
-        'isoMetadata.highValueDataset': checkedValue
-      }).valid === false
-    ) {
-      return;
-    }
     const response = await MetadataService.persistValue(CATEGORY_KEY, newSelection);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/07_AnnexThemeField.svelte
+++ b/src/lib/components/Form/Field/07_AnnexThemeField.svelte
@@ -39,7 +39,6 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onChange = async (newValue?: string[]) => {
-    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/09_CreatedField.svelte
+++ b/src/lib/components/Form/Field/09_CreatedField.svelte
@@ -33,7 +33,6 @@
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
-    if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
       inputValue ? new Date(inputValue).toISOString() : null

--- a/src/lib/components/Form/Field/09_CreatedField.svelte
+++ b/src/lib/components/Form/Field/09_CreatedField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.created';
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   let initialized = false;
@@ -30,32 +30,9 @@
   const fieldConfig = MetadataService.getFieldConfig<string>(9);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
-  const onChange = (evt: Event) => {
-    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
-    value = inputValue;
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          created: inputValue ? new Date(inputValue).toISOString() : null
-        }
-      };
-    }
-  };
-
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          created: inputValue ? new Date(inputValue).toISOString() : null
-        }
-      };
-    }
     if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
@@ -74,7 +51,6 @@
     label={t('09_CreatedField.label')}
     explanation={t('09_CreatedField.explanation')}
     {fieldConfig}
-    onchange={onChange}
     onblur={onBlur}
     {validationResult}
   />

--- a/src/lib/components/Form/Field/10_PublishedField.svelte
+++ b/src/lib/components/Form/Field/10_PublishedField.svelte
@@ -33,8 +33,6 @@
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
-    if (fieldConfig?.required && !inputValue) return;
-    if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
       inputValue ? new Date(inputValue).toISOString() : null

--- a/src/lib/components/Form/Field/10_PublishedField.svelte
+++ b/src/lib/components/Form/Field/10_PublishedField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.published';
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   let initialized = false;
@@ -29,45 +29,18 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(10);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
-  const toIsoDate = (inputValue: string) =>
-    inputValue ? new Date(inputValue).toISOString() : null;
-  let hasUnsavedLocalChange = $state(false);
-
-  $effect(() => {
-    if (!hasUnsavedLocalChange) {
-      return;
-    }
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-    const localValue = toIsoDate(value);
-    if (formState.metadata.isoMetadata.published === localValue) {
-      return;
-    }
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        published: localValue
-      }
-    };
-  });
-
-  const onChange = (evt: Event) => {
-    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
-    value = inputValue;
-    hasUnsavedLocalChange = true;
-  };
 
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
     if (fieldConfig?.required && !inputValue) return;
     if (fieldConfig?.validator(inputValue).valid === false) return;
-    const response = await MetadataService.persistValue(KEY, toIsoDate(inputValue));
+    const response = await MetadataService.persistValue(
+      KEY,
+      inputValue ? new Date(inputValue).toISOString() : null
+    );
 
     if (response.ok) {
-      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -80,7 +53,6 @@
     label={t('10_PublishedField.label')}
     explanation={t('10_PublishedField.explanation')}
     {fieldConfig}
-    onchange={onChange}
     onblur={onBlur}
     {validationResult}
   />

--- a/src/lib/components/Form/Field/11_LastUpdatedField.svelte
+++ b/src/lib/components/Form/Field/11_LastUpdatedField.svelte
@@ -17,7 +17,7 @@
   const formContext = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formContext.metadata);
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY, metadata));
   let value = $state('');
   let initialized = false;
@@ -38,32 +38,9 @@
 
   let showCheckmark = $state(false);
 
-  const onChange = (evt: Event) => {
-    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
-    value = inputValue;
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          modified: inputValue ? new Date(inputValue).toISOString() : null
-        }
-      };
-    }
-  };
-
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          modified: inputValue ? new Date(inputValue).toISOString() : null
-        }
-      };
-    }
     if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
@@ -81,7 +58,6 @@
     key={KEY}
     label={t('11_LastUpdatedField.label')}
     explanation={t('11_LastUpdatedField.explanation')}
-    onchange={onChange}
     onblur={onBlur}
     {fieldConfig}
     {validationResult}

--- a/src/lib/components/Form/Field/11_LastUpdatedField.svelte
+++ b/src/lib/components/Form/Field/11_LastUpdatedField.svelte
@@ -41,7 +41,6 @@
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
-    if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
       inputValue ? new Date(inputValue).toISOString() : null

--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -52,9 +52,6 @@
   let toValidationResult = $derived(toFieldConfig?.validator(endValue, [startValue]));
 
   const onBlur = async (key: string) => {
-    if (hasInvalidFields) {
-      return;
-    }
     const value = key === FROM_KEY ? startValue : endValue!;
     const valueToPersist = value ? new Date(value).toISOString() : null;
     const response = await MetadataService.persistValue(key, valueToPersist);

--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -11,7 +11,7 @@
   const FROM_KEY = 'isoMetadata.validFrom';
   const TO_KEY = 'isoMetadata.validTo';
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const startValueFromData = $derived(getValue<string>(FROM_KEY));
   let startValue = $state('');
   let startInitialized = false;
@@ -52,16 +52,6 @@
   let toValidationResult = $derived(toFieldConfig?.validator(endValue, [startValue]));
 
   const onBlur = async (key: string) => {
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          validFrom: startValue ? new Date(startValue).toISOString() : null,
-          validTo: endValue ? new Date(endValue).toISOString() : null
-        }
-      };
-    }
     if (hasInvalidFields) {
       return;
     }
@@ -72,25 +62,6 @@
       showCheckmark = true;
     }
     invalidateAll();
-  };
-
-  const onChange = (key: string, evt: Event) => {
-    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
-    if (key === FROM_KEY) {
-      startValue = inputValue;
-    } else {
-      endValue = inputValue;
-    }
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          validFrom: startValue ? new Date(startValue).toISOString() : null,
-          validTo: endValue ? new Date(endValue).toISOString() : null
-        }
-      };
-    }
   };
 
   let hasInvalidFields = $derived.by(() => {
@@ -116,7 +87,6 @@
       <DateInput
         bind:value={startValue}
         label={t('12_ValidityRangeField.label_from')}
-        onchange={(evt) => onChange(FROM_KEY, evt)}
         onblur={() => onBlur(FROM_KEY)}
         fieldConfig={fromFieldConfig}
         validationResult={fromValidationResult}
@@ -124,7 +94,6 @@
       <DateInput
         bind:value={endValue}
         label={t('12_ValidityRangeField.label_to')}
-        onchange={(evt) => onChange(TO_KEY, evt)}
         onblur={() => onBlur(TO_KEY)}
         fieldConfig={toFieldConfig}
         validationResult={toValidationResult}

--- a/src/lib/components/Form/Field/13_TopicCategory.svelte
+++ b/src/lib/components/Form/Field/13_TopicCategory.svelte
@@ -31,7 +31,6 @@
   let disabled = $derived(!!annexValue?.length && profileValue !== 'ISO');
 
   const onChange = async (newValue?: string[]) => {
-    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
+++ b/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
@@ -39,7 +39,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue?: string) => {
-    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
+++ b/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
@@ -27,7 +27,7 @@
     { key: 'unknown', label: 'unbekannt' }
   ];
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -39,15 +39,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue?: string) => {
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          maintenanceFrequency: newValue as MaintenanceFrequency
-        }
-      };
-    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/Field/15_KeywordsField.svelte
+++ b/src/lib/components/Form/Field/15_KeywordsField.svelte
@@ -99,7 +99,6 @@
   };
 
   const persistKeywords = async () => {
-    if (validationResult?.valid === false) return;
     const keywords: Keywords = valueFromData || {
       default: []
     };

--- a/src/lib/components/Form/Field/15_KeywordsField.svelte
+++ b/src/lib/components/Form/Field/15_KeywordsField.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { getFormContext } from '$lib/context/FormContext.svelte';
-  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import { onMount } from 'svelte';
-  import { getContext } from 'svelte';
   import Chip, { Set as ChipSet, Text, TrailingIcon } from '@smui/chips';
   import Autocomplete from '@smui-extra/autocomplete';
   import Dialog, { Actions, Content, Title } from '@smui/dialog';
@@ -25,7 +23,6 @@
   let { metadataid } = page.params;
 
   const { getValue } = getFormContext();
-  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   let value = $state<string[]>([]);
   const valueFromData = $derived(getValue<Keywords>(KEY));
   $effect(() => {
@@ -38,10 +35,7 @@
   let uniqueKeywords = $derived(Array.from(new Set([...autoKeywords, ...value])));
   let searchValue = $state('');
   const fieldConfig = MetadataService.getFieldConfig<Keywords>(15);
-  const toKeywords = (keywords: string[]): Keywords => ({
-    default: keywords.map((entry) => ({ keyword: entry }))
-  });
-  let validationResult = $derived(fieldConfig?.validator(toKeywords(value)));
+  let validationResult = $derived(fieldConfig?.validator(valueFromData));
 
   let dialogOpen = $state(false);
   let newKeyword = $state('');
@@ -105,19 +99,14 @@
   };
 
   const persistKeywords = async () => {
-    const keywords: Keywords = toKeywords(value);
-
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          keywords
-        }
-      };
-    }
-
     if (validationResult?.valid === false) return;
+    const keywords: Keywords = valueFromData || {
+      default: []
+    };
+    keywords.default = value
+      // filter autokeywords from value to avoid duplicates
+      .filter((kw) => !autoKeywords.includes(kw))
+      .map((entry) => ({ keyword: entry }));
 
     const response = await MetadataService.persistValue(KEY, keywords);
     if (response.ok) {

--- a/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'technicalMetadata.deliveredCrs';
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -21,15 +21,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
-    if (formState.metadata?.technicalMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        technicalMetadata: {
-          ...formState.metadata.technicalMetadata,
-          deliveredCrs: value
-        }
-      };
-    }
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {

--- a/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
@@ -21,7 +21,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
-    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
@@ -17,7 +17,7 @@
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -29,15 +29,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onSelectionChange = async (newValue?: string) => {
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          crs: newValue as string
-        }
-      };
-    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
@@ -29,7 +29,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onSelectionChange = async (newValue?: string) => {
-    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/18_ExtentField.svelte
+++ b/src/lib/components/Form/Field/18_ExtentField.svelte
@@ -115,9 +115,6 @@
   };
 
   const sendValue = async () => {
-    if (hasInvalidFields) {
-      return;
-    }
     const response = await MetadataService.persistValue(KEY, value4326);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/18_ExtentField.svelte
+++ b/src/lib/components/Form/Field/18_ExtentField.svelte
@@ -7,7 +7,7 @@
   import Button, { Icon, Label } from '@smui/button';
   import SelectInput from '../Inputs/SelectInput.svelte';
   import { getHighestRole, registerCRSCodes, transformExtent } from '$lib/util';
-  import { onMount, tick } from 'svelte';
+  import { onMount } from 'svelte';
   import { toast } from 'svelte-french-toast';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import type { CRSOption } from '$lib/models/api';
@@ -158,9 +158,8 @@
             type="button"
             variant={matchingOption?.title === option.title ? 'raised' : 'text'}
             title={option.title}
-            onclick={async () => {
+            onclick={() => {
               value4326 = option.value;
-              await tick();
               sendValue();
             }}
           >

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -2,7 +2,6 @@
   import type { Contact, Contacts } from '$lib/models/metadata';
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
-  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
@@ -13,7 +12,6 @@
   import { page } from '$app/state';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
-  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -23,7 +21,6 @@
   const KEY = 'isoMetadata.pointsOfContact';
 
   const { getValue } = getFormContext();
-  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   let contacts = $state<Contact[]>([]);
   const valueFromData = $derived(getValue<Contacts>(KEY));
 
@@ -87,16 +84,6 @@
   };
 
   const persistContacts = async (evt?: FocusEvent) => {
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          pointsOfContact: contacts
-        }
-      };
-    }
-
     if (hasInvalidFields) {
       return;
     }

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -29,14 +29,10 @@
 
   // important that this is not a state
   let previousValueAsString: string;
-  let hasUnsavedLocalChange = $state(false);
 
   const popconfirm = $derived(getPopconfirm());
 
   $effect(() => {
-    if (hasUnsavedLocalChange) {
-      return;
-    }
     // this check prevents rerendering if nothing has actually changed
     const newValueAsString = JSON.stringify(valueFromData);
     if (
@@ -109,7 +105,6 @@
     const focusedElement = evt?.relatedTarget as HTMLElement | null;
     const response = await MetadataService.persistValue(KEY, contacts);
     if (response.ok) {
-      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
 
@@ -151,37 +146,6 @@
       }
     );
   };
-
-  const onContactChange = () => {
-    hasUnsavedLocalChange = true;
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          pointsOfContact: contacts
-        }
-      };
-    }
-  };
-
-  $effect(() => {
-    if (!hasUnsavedLocalChange || !formState.metadata?.isoMetadata) {
-      return;
-    }
-    const serverValue = JSON.stringify(formState.metadata.isoMetadata.pointsOfContact || []);
-    const localValue = JSON.stringify(contacts || []);
-    if (serverValue === localValue) {
-      return;
-    }
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        pointsOfContact: contacts
-      }
-    };
-  });
 
   let hasInvalidFields = $derived.by(() => {
     if (!fieldConfig) return false;
@@ -234,7 +198,6 @@
           <TextInput
             bind:value={contact.name}
             label={t('19_ContactsField.name')}
-            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={nameConfig}
             validationResult={nameConfig?.validator(contact.name)}
@@ -252,7 +215,6 @@
           <TextInput
             bind:value={contact.organisation}
             label={t('19_ContactsField.organisation')}
-            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={organisationConfig}
             validationResult={organisationConfig?.validator(contact.organisation)}
@@ -270,7 +232,6 @@
           <TextInput
             bind:value={contact.phone}
             label={t('19_ContactsField.phone')}
-            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={phoneConfig}
             validationResult={phoneConfig?.validator(contact.phone)}
@@ -288,7 +249,6 @@
           <TextInput
             bind:value={contact.email}
             label={t('19_ContactsField.email')}
-            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={emailConfig}
             validationResult={emailConfig?.validator(contact.email)}

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -84,9 +84,6 @@
   };
 
   const persistContacts = async (evt?: FocusEvent) => {
-    if (hasInvalidFields) {
-      return;
-    }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;

--- a/src/lib/components/Form/Field/25_TermsOfUseField.svelte
+++ b/src/lib/components/Form/Field/25_TermsOfUseField.svelte
@@ -42,7 +42,6 @@
   };
 
   const onChange = async (newValue: string) => {
-    if (fieldConfig?.validator(Number(newValue)).valid === false) return;
     const response = await MetadataService.persistValue(KEY, Number(newValue));
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
+++ b/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
@@ -4,13 +4,14 @@
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import { page } from '$app/state';
+  import { ValidationService } from '$lib/services/ValidationService';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.termsOfUseSource';
   const TERMS_OF_USE_KEY = 'isoMetadata.termsOfUseId';
   const PRIVACY_KEY = 'isoMetadata.privacy';
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   const termsOfUseId = $derived(getValue<number>(TERMS_OF_USE_KEY));
   const privacy = $derived(getValue<string>(PRIVACY_KEY));
@@ -20,19 +21,9 @@
     value = valueFromData || '';
   });
 
-  $effect(() => {
-    if (!formState.metadata?.isoMetadata) return;
-    formState.metadata.isoMetadata.termsOfUseSource = value;
-  });
-
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(26);
-  let validationResult = $derived(
-    fieldConfig?.validator(value, {
-      'isoMetadata.termsOfUseId': termsOfUseId,
-      'isoMetadata.privacy': privacy
-    })
-  );
+  let validationResult = $derived(ValidationService.validateField(fieldConfig, value));
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
+++ b/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
@@ -26,7 +26,6 @@
   let validationResult = $derived(ValidationService.validateField(fieldConfig, value));
 
   const onBlur = async () => {
-    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -8,7 +8,6 @@
   import FieldTools from '../FieldTools.svelte';
   import NumberInput from '../Inputs/NumberInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
-  import { MetadataUpdateService } from '$lib/services/MetadataUpdateService';
   import FormField from '@smui/form-field';
   import Radio from '@smui/radio';
 
@@ -25,37 +24,24 @@
   let selected = $state<typeof RESOLUTION_KEY | typeof SCALE_KEY>();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formState.metadata);
-  let hasUnsavedLocalChange = $state(false);
 
   // TODO: check why this is a List
   const resolutionValueFromData = $derived(getValue<number[]>(RESOLUTION_KEY)?.[0]);
   let resolutionValue = $state<number | null>(null);
+  $effect(() => {
+    if (resolutionValueFromData) {
+      resolutionValue = resolutionValueFromData;
+      selected = RESOLUTION_KEY;
+    }
+  });
+
   const scaleValueFromData = $derived(getValue<number>(SCALE_KEY));
   let scaleValue = $state<number | null>(null);
   $effect(() => {
-    if (hasUnsavedLocalChange) {
-      return;
-    }
-    const hasResolution = resolutionValueFromData !== undefined && resolutionValueFromData !== null;
-    const hasScale = scaleValueFromData !== undefined && scaleValueFromData !== null;
-
-    if (hasResolution) {
-      resolutionValue = resolutionValueFromData;
-      scaleValue = hasScale ? scaleValueFromData : null;
-      selected = RESOLUTION_KEY;
-      return;
-    }
-
-    if (hasScale) {
+    if (scaleValueFromData) {
       scaleValue = scaleValueFromData;
-      resolutionValue = null;
       selected = SCALE_KEY;
-      return;
     }
-
-    resolutionValue = null;
-    scaleValue = null;
-    selected = undefined;
   });
 
   let showCheckmark = $state(false);
@@ -75,50 +61,36 @@
     !resolutionValidationResult?.valid && !scaleValidationResult?.valid
   );
 
-  const clearAllValues = async () => {
-    hasUnsavedLocalChange = true;
-    if (selected === RESOLUTION_KEY) {
-      resolutionValue = null;
-      if (formState.metadata?.isoMetadata) {
-        formState.metadata = {
-          ...formState.metadata,
-          isoMetadata: {
-            ...formState.metadata.isoMetadata,
-            resolutions: null
-          }
-        };
-      }
-    } else if (selected === SCALE_KEY) {
-      scaleValue = null;
-      if (formState.metadata?.isoMetadata) {
-        formState.metadata = {
-          ...formState.metadata,
-          isoMetadata: {
-            ...formState.metadata.isoMetadata,
-            scale: null
-          }
-        };
-      }
+  const syncLocalResolutionState = () => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
     }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        resolutions: resolutionValue ? [resolutionValue] : null,
+        scale: scaleValue
+      }
+    };
+  };
+
+  const clearAllValues = async () => {
+    scaleValue = null;
+    resolutionValue = null;
+    syncLocalResolutionState();
+    await updateResolution(null);
+    await updateScale(null);
   };
 
   const onBlur = async (event: FocusEvent) => {
-    hasUnsavedLocalChange = true;
+    syncLocalResolutionState();
     const target = event.target as HTMLInputElement;
     const minValue = target.getAttribute('min');
     const min = Number(minValue);
     if (!Number.isNaN(min) && Number(target.value) < min) {
       return;
-    }
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          resolutions: selected === RESOLUTION_KEY && resolutionValue ? [resolutionValue] : null,
-          scale: selected === SCALE_KEY ? scaleValue : null
-        }
-      };
     }
     const selectedValidationResult =
       selected === RESOLUTION_KEY ? resolutionValidationResult : scaleValidationResult;
@@ -126,40 +98,24 @@
       return;
     }
     if (selected === RESOLUTION_KEY) {
-      await updateScale(null);
-      const saved = await updateResolution(resolutionValue ? [resolutionValue] : null);
-      if (saved) {
-        hasUnsavedLocalChange = false;
-      }
+      await updateResolution(resolutionValue ? [resolutionValue] : null);
     } else {
-      await updateResolution(null);
-      const saved = await updateScale(scaleValue);
-      if (saved) {
-        hasUnsavedLocalChange = false;
-      }
+      await updateScale(scaleValue);
     }
   };
 
   const updateResolution = async (newValue: [number] | null) => {
-    const response =
-      newValue === null
-        ? await MetadataUpdateService.pushToQueue(RESOLUTION_KEY, null)
-        : await MetadataService.persistValue(RESOLUTION_KEY, newValue);
+    const response = await MetadataService.persistValue(RESOLUTION_KEY, newValue);
     if (response.ok) {
       showCheckmark = true;
     }
-    return response.ok;
   };
 
   const updateScale = async (newValue: number | null) => {
-    const response =
-      newValue === null
-        ? await MetadataUpdateService.pushToQueue(SCALE_KEY, null)
-        : await MetadataService.persistValue(SCALE_KEY, newValue);
+    const response = await MetadataService.persistValue(SCALE_KEY, newValue);
     if (response.ok) {
       showCheckmark = true;
     }
-    return response.ok;
   };
 </script>
 

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -61,31 +61,14 @@
     !resolutionValidationResult?.valid && !scaleValidationResult?.valid
   );
 
-  const syncLocalResolutionState = () => {
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        resolutions: resolutionValue ? [resolutionValue] : null,
-        scale: scaleValue
-      }
-    };
-  };
-
   const clearAllValues = async () => {
     scaleValue = null;
     resolutionValue = null;
-    syncLocalResolutionState();
     await updateResolution(null);
     await updateScale(null);
   };
 
   const onBlur = async (event: FocusEvent) => {
-    syncLocalResolutionState();
     const target = event.target as HTMLInputElement;
     const minValue = target.getAttribute('min');
     const min = Number(minValue);

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -75,11 +75,6 @@
     if (!Number.isNaN(min) && Number(target.value) < min) {
       return;
     }
-    const selectedValidationResult =
-      selected === RESOLUTION_KEY ? resolutionValidationResult : scaleValidationResult;
-    if (selectedValidationResult?.valid === false) {
-      return;
-    }
     if (selected === RESOLUTION_KEY) {
       await updateResolution(resolutionValue ? [resolutionValue] : null);
     } else {

--- a/src/lib/components/Form/Field/29_PreviewField.svelte
+++ b/src/lib/components/Form/Field/29_PreviewField.svelte
@@ -18,11 +18,7 @@
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
-  let hasUnsavedLocalChange = $state(false);
   $effect(() => {
-    if (hasUnsavedLocalChange) {
-      return;
-    }
     value = valueFromData || '';
   });
 
@@ -52,7 +48,6 @@
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
-      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -61,9 +56,6 @@
 <div class="preview-field">
   <TextInput
     bind:value
-    onchange={() => {
-      hasUnsavedLocalChange = true;
-    }}
     label={t('29_PreviewField.label')}
     explanation={t('29_PreviewField.explanation')}
     {fieldConfig}

--- a/src/lib/components/Form/Field/29_PreviewField.svelte
+++ b/src/lib/components/Form/Field/29_PreviewField.svelte
@@ -1,21 +1,15 @@
 <script lang="ts">
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
-  import {
-    FORMSTATE_CONTEXT,
-    getFormContext,
-    type FormState
-  } from '$lib/context/FormContext.svelte';
+  import { getFormContext } from '$lib/context/FormContext.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import type { ValidationResult } from '../FieldsConfig';
   import { page } from '$app/state';
-  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.preview';
 
   const { getValue } = getFormContext();
-  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   $effect(() => {
@@ -25,24 +19,6 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(29);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
-
-  $effect(() => {
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-
-    if (formState.metadata.isoMetadata.preview === value) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        preview: value
-      }
-    };
-  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/29_PreviewField.svelte
+++ b/src/lib/components/Form/Field/29_PreviewField.svelte
@@ -21,7 +21,6 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
-    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/30_ContentDescription.svelte
+++ b/src/lib/components/Form/Field/30_ContentDescription.svelte
@@ -21,7 +21,6 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onBlur = async () => {
-    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/31_TechnicalDescription.svelte
+++ b/src/lib/components/Form/Field/31_TechnicalDescription.svelte
@@ -21,7 +21,6 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onBlur = async () => {
-    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -2,7 +2,6 @@
   import type { Lineage, MetadataCollection } from '$lib/models/metadata';
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
-  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '../Inputs/TextInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
@@ -13,7 +12,6 @@
   import { getPopconfirm } from '$lib/context/PopConfirmContext.svelte';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
-  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -23,7 +21,6 @@
   const KEY = 'isoMetadata.lineage';
 
   const { getValue } = getFormContext();
-  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<Lineage[]>(KEY));
   let lineages = $state<Lineage[]>([]);
 
@@ -99,8 +96,6 @@
   };
 
   const persistLineages = async (evt?: FocusEvent) => {
-    syncLocalLineageState();
-
     if (hasInvalidFields) {
       return;
     }
@@ -123,29 +118,6 @@
       elementToFocus?.focus();
     }, 10);
   };
-
-  const syncLocalLineageState = () => {
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-
-    const currentLineage = formState.metadata.isoMetadata.lineage || [];
-    if (JSON.stringify(currentLineage) === JSON.stringify(lineages)) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        lineage: lineages
-      }
-    };
-  };
-
-  $effect(() => {
-    syncLocalLineageState();
-  });
 
   const addItem = (evt: MouseEvent) => {
     evt.preventDefault();

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -96,9 +96,6 @@
   };
 
   const persistLineages = async (evt?: FocusEvent) => {
-    if (hasInvalidFields) {
-      return;
-    }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;

--- a/src/lib/components/Form/Field/38_InspireAnnexVersionField.svelte
+++ b/src/lib/components/Form/Field/38_InspireAnnexVersionField.svelte
@@ -40,7 +40,6 @@
   );
 
   const onBlur = async () => {
-    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
+++ b/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
@@ -26,7 +26,6 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onChange = async (newValue?: string[]) => {
-    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
+++ b/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
@@ -14,7 +14,7 @@
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
-  const { getValue, formState } = getFormContext();
+  const { getValue } = getFormContext();
   const valueFromData = $derived(getValue<string[]>(KEY));
   let value = $state<string[]>();
   $effect(() => {
@@ -26,15 +26,6 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onChange = async (newValue?: string[]) => {
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          spatialRepresentationTypes: newValue
-        }
-      };
-    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/Field/41_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/41_AdditionalInformation.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
-  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
@@ -12,7 +11,6 @@
   import { page } from '$app/state';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
-  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -22,7 +20,6 @@
   const KEY = 'isoMetadata.contentDescriptions';
 
   const { getValue } = getFormContext();
-  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<ContentDescription[]>(KEY));
   let contentDescriptions = $state<ContentDescription[]>([]);
 
@@ -60,8 +57,6 @@
   const urlFieldConfig = MetadataService.getFieldConfig<string>(44);
 
   const persistContentDescriptions = async (evt?: FocusEvent) => {
-    syncLocalContentDescriptionsState();
-
     if (hasInvalidFields) {
       return;
     }
@@ -79,29 +74,6 @@
       elementToFocus?.focus();
     }, 10);
   };
-
-  const syncLocalContentDescriptionsState = () => {
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-
-    const currentContentDescriptions = formState.metadata.isoMetadata.contentDescriptions || [];
-    if (JSON.stringify(currentContentDescriptions) === JSON.stringify(contentDescriptions)) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        contentDescriptions
-      }
-    };
-  };
-
-  $effect(() => {
-    syncLocalContentDescriptionsState();
-  });
 
   const addItem = (evt: MouseEvent) => {
     evt.preventDefault();

--- a/src/lib/components/Form/Field/41_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/41_AdditionalInformation.svelte
@@ -57,9 +57,6 @@
   const urlFieldConfig = MetadataService.getFieldConfig<string>(44);
 
   const persistContentDescriptions = async (evt?: FocusEvent) => {
-    if (hasInvalidFields) {
-      return;
-    }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;

--- a/src/lib/components/Form/Field/70_InspireFormatName.svelte
+++ b/src/lib/components/Form/Field/70_InspireFormatName.svelte
@@ -51,8 +51,6 @@
   let options: Option[] = $state([]);
 
   const onChange = async (newValue?: string) => {
-    if (ValidationService.validateField(fieldConfig, newValue, { metadata }).valid === false)
-      return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -740,7 +740,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     profileId: 45,
     key: 'isoMetadata.services.workspace',
     collectionKey: 'isoMetadata.services',
-    extraParams: ['PARENT_VALUE', 'HIGHEST_ROLE', 'isoMetadata.services'],
+    extraParams: ['PARENT_VALUE', 'HIGHEST_ROLE'],
     validator: (workspace: Service['workspace'], extraParams) => {
       const highestRole = extraParams?.['HIGHEST_ROLE'] as string;
       const required = ['MdeEditor', 'MdeAdministrator'].includes(highestRole);
@@ -753,17 +753,6 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
           valid: false,
           helpText:
             'Bitte geben Sie einen gültigen Workspace an. Nur Buchstaben, Zahlen und Unterstriche sind erlaubt.'
-        };
-      }
-      const service = extraParams?.['PARENT_VALUE'] as Service;
-      const services = (extraParams?.['isoMetadata.services'] || []) as Service[];
-      const hasDuplicateWorkspace = services.some(
-        (entry) => entry.id !== service?.id && entry.workspace === workspace
-      );
-      if (hasDuplicateWorkspace) {
-        return {
-          valid: false,
-          helpText: 'Der angegebene Identifikator ist bereits vergeben.'
         };
       }
       return { valid };

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -758,10 +758,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       const service = extraParams?.['PARENT_VALUE'] as Service;
       const services = (extraParams?.['isoMetadata.services'] || []) as Service[];
       const hasDuplicateWorkspace = services.some(
-        (entry) =>
-          entry.id !== service?.id &&
-          entry.workspace === workspace &&
-          entry.serviceType === service?.serviceType
+        (entry) => entry.id !== service?.id && entry.workspace === workspace
       );
       if (hasDuplicateWorkspace) {
         return {

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -526,11 +526,10 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
   {
     profileId: 26,
     key: 'isoMetadata.termsOfUseSource',
-    extraParams: ['isoMetadata.termsOfUseId', 'isoMetadata.privacy'],
+    extraParams: ['isoMetadata.termsOfUseId'],
     validator: (val, extraParams) => {
       const termsOfUseId = extraParams?.['isoMetadata.termsOfUseId'];
-      const privacy = extraParams?.['isoMetadata.privacy'];
-      const isRequired = privacy === 'NONE' && !!termsOfUseId && termsOfUseId !== 1;
+      const isRequired = termsOfUseId !== 1;
       if (isRequired && !isDefined(val)) {
         return {
           valid: false,

--- a/src/lib/components/Form/Form.svelte
+++ b/src/lib/components/Form/Form.svelte
@@ -103,7 +103,8 @@
     formContext.clearActiveHelp();
 
     goto(`#${section}`, {
-      replaceState: true
+      replaceState: true,
+      invalidateAll: true
     });
     await tick();
   };

--- a/src/lib/components/Form/Inputs/DateInput.svelte
+++ b/src/lib/components/Form/Inputs/DateInput.svelte
@@ -68,10 +68,6 @@
     id={key}
     name={key}
     bind:value
-    oninput={(evt) => {
-      value = (evt.currentTarget as HTMLInputElement).value;
-      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLInputElement });
-    }}
     onblur={(evt) => {
       value = (evt.currentTarget as HTMLInputElement).value;
       onblur?.(evt);

--- a/src/lib/components/Form/Inputs/TextAreaInput.svelte
+++ b/src/lib/components/Form/Inputs/TextAreaInput.svelte
@@ -50,9 +50,6 @@
   <textarea
     {maxlength}
     bind:value
-    oninput={(evt) => {
-      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLTextAreaElement });
-    }}
     onfocus={(evt) => {
       fieldHasFocus = true;
       onfocus?.(evt);

--- a/src/lib/components/Form/Inputs/TextInput.svelte
+++ b/src/lib/components/Form/Inputs/TextInput.svelte
@@ -53,9 +53,6 @@
   <input
     type="text"
     autocomplete="off"
-    oninput={(evt) => {
-      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLInputElement });
-    }}
     onfocus={(evt) => {
       fieldHasFocus = true;
       onfocus?.(evt);

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -22,8 +22,6 @@
   import { logger } from 'loggisch';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
-  import { validateFeatureTypes } from './validation';
-  import { ValidationService } from '$lib/services/ValidationService';
 
   const t = $derived(page.data.t);
 
@@ -76,10 +74,9 @@
     return onChange(service, true);
   }
 
-  async function set<K extends keyof Service>(key: K, value: Service[K], persist?: boolean) {
+  async function set<K extends keyof Service>(key: K, value: Service[K]) {
     service = setNestedValue(service, key, value);
-    const shouldPersist = persist ?? shouldPersistFieldValue(key, value);
-    const response = await onChange(service, shouldPersist);
+    const response = await onChange(service, shouldPersistFieldValue(key, value));
     if (response.ok) {
       if (key === 'serviceType') {
         onServiceTypeChange(value as ServiceType);
@@ -103,10 +100,9 @@
   const shouldPersistFieldValue = <K extends keyof Service>(key: K, value: Service[K]) => {
     if (key === 'workspace') {
       const fieldConfig = MetadataService.getFieldConfig<string>(45);
-      return ValidationService.validateField(fieldConfig, value as Service['workspace'], {
+      return fieldConfig?.validator(value as Service['workspace'], {
         ['PARENT_VALUE']: service,
-        ['HIGHEST_ROLE']: highestRole,
-        metadata
+        ['HIGHEST_ROLE']: highestRole
       }).valid;
     }
     if (key === 'preview') {
@@ -125,16 +121,9 @@
     }
     if (key === 'featureTypes') {
       const fieldConfig = MetadataService.getFieldConfig<Service['featureTypes']>(56);
-      const featureTypes = value as Service['featureTypes'];
-      const hasValidFeatureTypeCollection = fieldConfig?.validator(featureTypes, {
+      return fieldConfig?.validator(value as Service['featureTypes'], {
         ['PARENT_VALUE']: service
       }).valid;
-      const hasInvalidFeatureTypes =
-        validateFeatureTypes(featureTypes || [], {
-          metadata,
-          HIGHEST_ROLE: highestRole
-        }).size > 0;
-      return hasValidFeatureTypeCollection && !hasInvalidFeatureTypes;
     }
     if (key === 'serviceType') {
       const fieldConfig = MetadataService.getFieldConfig<ServiceType>(58);
@@ -144,26 +133,9 @@
     return true;
   };
 
-  async function onLayersChange(layers: Layer[], persist = true) {
+  async function onLayersChange(layers: Layer[]) {
     const serviceIdentification = service?.serviceIdentification;
     if (!serviceIdentification) return Promise.reject('Service identification is missing');
-
-    if (formContext.metadata) {
-      formContext.metadata = {
-        ...formContext.metadata,
-        clientMetadata: {
-          ...formContext.metadata.clientMetadata,
-          layers: {
-            ...(formContext.metadata.clientMetadata?.layers || {}),
-            [serviceIdentification]: layers
-          }
-        }
-      };
-    }
-
-    if (!persist) {
-      return new Response(null, { status: 422, statusText: 'Validation failed' });
-    }
 
     const response = await fetch(
       `${page.url.origin}${page.url.pathname}/updateLayers/${serviceIdentification}`,
@@ -180,27 +152,23 @@
 
     if (!response.ok) {
       toast.error(t('serviceform.layer_update_error', { statusText: response.statusText }));
-    } else {
-      await invalidateAll();
     }
+    invalidateAll();
     return response;
   }
 </script>
 
 <div class="service-form">
   <ServiceType_58 value={service.serviceType} onChange={onServiceTypeChange} />
-  <ServiceTitle_59
-    value={service.title}
-    onChange={(title, persist) => set('title', title, persist)}
-  />
+  <ServiceTitle_59 value={service.title} onChange={(title) => set('title', title)} />
   <ServiceShortDescription_60
     value={service.shortDescription}
-    onChange={(shortDescription, persist) => set('shortDescription', shortDescription, persist)}
+    onChange={(shortDescription) => set('shortDescription', shortDescription)}
   />
   <ServiceWorkspace_45
     value={service.workspace}
     {service}
-    onChange={(workspace, persist) => set('workspace', workspace, persist)}
+    onChange={(workspace) => set('workspace', workspace)}
   />
   <ServicePreview_46
     value={service.preview}
@@ -218,7 +186,7 @@
     <FeatureTypeForm_56
       {service}
       value={service.featureTypes}
-      onChange={(featureTypes, persist) => set('featureTypes', featureTypes, persist)}
+      onChange={(featureTypes) => set('featureTypes', featureTypes)}
     />
   {/if}
 </div>

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -20,14 +20,12 @@
   import { toast } from 'svelte-french-toast';
   import { invalidateAll } from '$app/navigation';
   import { logger } from 'loggisch';
-  import { getAccessToken } from '$lib/context/TokenContext.svelte';
-  import { getHighestRole } from '$lib/util';
 
   const t = $derived(page.data.t);
 
   export type ServiceFormProps = {
     service: Service;
-    onChange: (service: Service, persist?: boolean) => Promise<Response>;
+    onChange: (service: Service) => Promise<Response>;
   };
 
   let { service, onChange }: ServiceFormProps = $props();
@@ -35,8 +33,6 @@
   const { getValue } = getFormContext();
   const formContext = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formContext.metadata);
-  const token = $derived(getAccessToken());
-  const highestRole = $derived(getHighestRole(token));
 
   const layers = $derived.by((): Layer[] => {
     const layersMap: Record<string, Layer[]> = metadata?.clientMetadata?.layers;
@@ -71,12 +67,13 @@
       // Remove feature types associated with the service
       delete service.featureTypes;
     }
-    return onChange(service, true);
+    return onChange(service);
   }
 
-  async function set<K extends keyof Service>(key: K, value: Service[K]) {
+  async function set(key: string, value: Service[keyof Service]) {
     service = setNestedValue(service, key, value);
-    const response = await onChange(service, shouldPersistFieldValue(key, value));
+
+    const response = await onChange(service);
     if (response.ok) {
       if (key === 'serviceType') {
         onServiceTypeChange(value as ServiceType);
@@ -96,42 +93,6 @@
     }
     return response;
   }
-
-  const shouldPersistFieldValue = <K extends keyof Service>(key: K, value: Service[K]) => {
-    if (key === 'workspace') {
-      const fieldConfig = MetadataService.getFieldConfig<string>(45);
-      return fieldConfig?.validator(value as Service['workspace'], {
-        ['PARENT_VALUE']: service,
-        ['HIGHEST_ROLE']: highestRole
-      }).valid;
-    }
-    if (key === 'preview') {
-      const fieldConfig = MetadataService.getFieldConfig<string>(46);
-      return fieldConfig?.validator(value as Service['preview'], {
-        ['PARENT_VALUE']: service
-      }).valid;
-    }
-    if (key === 'title') {
-      const fieldConfig = MetadataService.getFieldConfig<string>(59);
-      return fieldConfig?.validator(value as Service['title']).valid;
-    }
-    if (key === 'shortDescription') {
-      const fieldConfig = MetadataService.getFieldConfig<string>(60);
-      return fieldConfig?.validator(value as Service['shortDescription']).valid;
-    }
-    if (key === 'featureTypes') {
-      const fieldConfig = MetadataService.getFieldConfig<Service['featureTypes']>(56);
-      return fieldConfig?.validator(value as Service['featureTypes'], {
-        ['PARENT_VALUE']: service
-      }).valid;
-    }
-    if (key === 'serviceType') {
-      const fieldConfig = MetadataService.getFieldConfig<ServiceType>(58);
-      return fieldConfig?.validator(value as Service['serviceType']).valid;
-    }
-
-    return true;
-  };
 
   async function onLayersChange(layers: Layer[]) {
     const serviceIdentification = service?.serviceIdentification;

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -77,11 +77,6 @@
   }
 
   async function set<K extends keyof Service>(key: K, value: Service[K], persist?: boolean) {
-    const serviceIdentification = service?.serviceIdentification;
-    const localLayersBeforePersist = serviceIdentification
-      ? formContext.metadata?.clientMetadata?.layers?.[serviceIdentification]
-      : undefined;
-
     service = setNestedValue(service, key, value);
     const shouldPersist = persist ?? shouldPersistFieldValue(key, value);
     const response = await onChange(service, shouldPersist);
@@ -101,25 +96,6 @@
         }
       }
       await invalidateAll();
-      // keep local layer edits (including invalid, not persisted values) when only service fields change
-      if (
-        key !== 'serviceType' &&
-        serviceIdentification &&
-        (service.serviceType === 'WMS' || service.serviceType === 'WMTS') &&
-        localLayersBeforePersist &&
-        formContext.metadata
-      ) {
-        formContext.metadata = {
-          ...formContext.metadata,
-          clientMetadata: {
-            ...formContext.metadata.clientMetadata,
-            layers: {
-              ...(formContext.metadata.clientMetadata?.layers || {}),
-              [serviceIdentification]: localLayersBeforePersist
-            }
-          }
-        };
-      }
     }
     return response;
   }

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -145,7 +145,7 @@
     );
   }
 
-  async function updateService(id: string, newService: Service, persist = true) {
+  async function updateService(id: string, newService: Service) {
     if (!id || !newService) {
       return Promise.reject('Invalid parameters');
     }
@@ -155,21 +155,6 @@
       }
       return service;
     });
-
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          services
-        }
-      };
-    }
-
-    if (!persist) {
-      return new Response(null, { status: 422, statusText: 'Validation failed' });
-    }
-
     return persistServices(id);
   }
 
@@ -241,8 +226,8 @@
     <span>
       <ServiceForm_40
         service={activeService}
-        onChange={(newService, persist) => {
-          return updateService(activeService?.id, newService, persist);
+        onChange={(newService) => {
+          return updateService(activeService?.id, newService);
         }}
       />
     </span>

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -11,7 +11,6 @@
   import { getPopconfirm } from '$lib/context/PopConfirmContext.svelte';
   import { validateService } from './validation';
   import { MetadataService } from '$lib/services/MetadataService';
-  import { ValidationService } from '$lib/services/ValidationService';
 
   const t = $derived(page.data.t);
 
@@ -32,7 +31,6 @@
 
   let initialServices = getValue<Service[]>(KEY);
   let services = $state<Service[]>([]);
-  let lastPersistedServices = $state<Service[]>(initialServices || []);
   let tabs = $derived<Tab[]>(
     services.map((service) => {
       const mappingService = service.serviceType === 'WMS' || service.serviceType === 'WMTS';
@@ -76,42 +74,14 @@
 
   $effect(() => {
     services = initialServices || [];
-    lastPersistedServices = initialServices || [];
     activeTab = initialServices?.length ? initialServices[0].id : '';
   });
 
   let visibleCheckmarks = $state<Record<string, boolean>>({});
 
-  const isWorkspacePersistable = (service: Service, serviceList: Service[]) => {
-    const fieldConfig = MetadataService.getFieldConfig<string>(45);
-    const validation = ValidationService.validateField(fieldConfig, service.workspace, {
-      metadata,
-      PARENT_VALUE: service,
-      HIGHEST_ROLE: highestRole
-    });
-    if (validation.valid === false) return false;
-
-    return !serviceList.some(
-      (entry) => entry.id !== service.id && entry.workspace === service.workspace
-    );
-  };
-
-  const getPersistableServices = (serviceList: Service[]) => {
-    return serviceList.map((service) => {
-      if (isWorkspacePersistable(service, serviceList)) {
-        return service;
-      }
-
-      const lastPersisted = lastPersistedServices.find((entry) => entry.id === service.id);
-      return lastPersisted ? { ...service, workspace: lastPersisted.workspace } : service;
-    });
-  };
-
   const persistServices = async (id: string) => {
-    const persistableServices = getPersistableServices(services);
-    const response = await MetadataService.persistValue(KEY, persistableServices);
+    const response = await MetadataService.persistValue(KEY, services);
     if (response.ok) {
-      lastPersistedServices = persistableServices;
       visibleCheckmarks[id] = true;
     }
     return response;
@@ -272,7 +242,7 @@
       <ServiceForm_40
         service={activeService}
         onChange={(newService, persist) => {
-          return updateService(newService?.id, newService, persist);
+          return updateService(activeService?.id, newService, persist);
         }}
       />
     </span>

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -92,10 +92,7 @@
     if (validation.valid === false) return false;
 
     return !serviceList.some(
-      (entry) =>
-        entry.id !== service.id &&
-        entry.workspace === service.workspace &&
-        entry.serviceType === service.serviceType
+      (entry) => entry.id !== service.id && entry.workspace === service.workspace
     );
   };
 

--- a/src/lib/components/Form/service/48_LayersForm.svelte
+++ b/src/lib/components/Form/service/48_LayersForm.svelte
@@ -28,7 +28,7 @@
   export type LayersFormProps = {
     value?: Layer[];
     service?: Service;
-    onChange: (layers: Layer[], persist?: boolean) => Promise<Response>;
+    onChange: (layers: Layer[]) => Promise<Response>;
   };
 
   let { value: initialLayers, service, onChange }: LayersFormProps = $props();
@@ -84,7 +84,6 @@
         styleName: ''
       }
     ];
-    syncLocalLayers(layers);
     activeTabId = id;
     onChange(layers);
   }
@@ -96,7 +95,6 @@
       targetEl,
       async () => {
         layers = layers.filter((layer) => layer.id !== layerId);
-        syncLocalLayers(layers);
         if (activeTabId === layerId) {
           activeTabId = layers.length > 0 ? layers[layers.length - 1]?.id : undefined;
         }
@@ -113,7 +111,7 @@
     );
   }
 
-  function set(key: string, value: Layer[keyof Layer], persist?: boolean) {
+  function set(key: string, value: Layer[keyof Layer]) {
     layers = layers.map((layer) => {
       if (layer.id === activeTabId) {
         return {
@@ -123,25 +121,7 @@
       }
       return layer;
     });
-    syncLocalLayers(layers);
-    return onChange(layers, persist);
-  }
-
-  function syncLocalLayers(nextLayers: Layer[]) {
-    if (!formState.metadata || !serviceId) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      clientMetadata: {
-        ...formState.metadata.clientMetadata,
-        layers: {
-          ...(formState.metadata.clientMetadata?.layers || {}),
-          [serviceId]: nextLayers
-        }
-      }
-    };
+    return onChange(layers);
   }
 </script>
 
@@ -196,21 +176,15 @@
     </nav>
     <div class="content">
       {#if activeTabId && activeLayer}
-        <LayerTitle_49
-          value={activeLayer?.title}
-          onChange={(title, persist) => set('title', title, persist)}
-        />
-        <LayerName_50
-          value={activeLayer?.name}
-          onChange={(name, persist) => set('name', name, persist)}
-        />
+        <LayerTitle_49 value={activeLayer?.title} onChange={(title) => set('title', title)} />
+        <LayerName_50 value={activeLayer?.name} onChange={(name) => set('name', name)} />
         <LayerStyleTitle_52
           value={activeLayer?.styleTitle}
-          onChange={(styleTitle, persist) => set('styleTitle', styleTitle, persist)}
+          onChange={(styleTitle) => set('styleTitle', styleTitle)}
         />
         <LayerStyleName_51
           value={activeLayer?.styleName}
-          onChange={(styleName, persist) => set('styleName', styleName, persist)}
+          onChange={(styleName) => set('styleName', styleName)}
         />
         <LayerLegendImage_53
           value={activeLayer?.legendImage}
@@ -218,8 +192,7 @@
         />
         <LayerDescription_54
           value={activeLayer?.shortDescription}
-          onChange={(shortDescription, persist) =>
-            set('shortDescription', shortDescription, persist)}
+          onChange={(shortDescription) => set('shortDescription', shortDescription)}
         />
         <LayerDatasource_55
           value={activeLayer?.datasource}

--- a/src/lib/components/Form/service/56_FeatureTypeForm.svelte
+++ b/src/lib/components/Form/service/56_FeatureTypeForm.svelte
@@ -24,7 +24,7 @@
   export type FeatureTypeFormProps = {
     value?: FeatureType[];
     service: Service;
-    onChange: (featureTypes: FeatureType[], persist?: boolean) => Promise<Response>;
+    onChange: (featureTypes: FeatureType[]) => Promise<Response>;
   };
 
   let { value: initialFeatureTypes, onChange, service }: FeatureTypeFormProps = $props();
@@ -110,7 +110,7 @@
     );
   }
 
-  function set(key: string, value: FeatureType[keyof FeatureType], persist?: boolean) {
+  function set(key: string, value: FeatureType[keyof FeatureType]) {
     featureTypes = featureTypes.map((featureType) => {
       if (featureType.id === activeTabId) {
         return {
@@ -121,7 +121,7 @@
       return featureType;
     });
     syncLocalFeatureTypes(featureTypes);
-    return onChange(featureTypes, persist);
+    return onChange(featureTypes);
   }
 
   function syncLocalFeatureTypes(nextFeatureTypes: FeatureType[]) {
@@ -232,22 +232,21 @@
       {#if activeTabId && activeFeatureType}
         <FeatureTypeTitle_61
           value={activeFeatureType?.title}
-          onChange={(title, persist) => set('title', title, persist)}
+          onChange={(title) => set('title', title)}
         />
         <FeatureTypeName_62
           featureType={activeFeatureType}
           value={activeFeatureType?.name}
-          onChange={(name, persist) => set('name', name, persist)}
+          onChange={(name) => set('name', name)}
         />
         <FeatureTypeDescription_69
           value={activeFeatureType?.shortDescription}
-          onChange={(shortDescription, persist) =>
-            set('shortDescription', shortDescription, persist)}
+          onChange={(shortDescription) => set('shortDescription', shortDescription)}
         />
         <ColumnsForm_63
           featureType={activeFeatureType}
           value={activeFeatureType?.columns}
-          onChange={(columns, persist) => set('columns', columns, persist)}
+          onChange={(columns) => set('columns', columns)}
         />
       {/if}
     </div>

--- a/src/lib/components/Form/service/56_FeatureTypeForm.svelte
+++ b/src/lib/components/Form/service/56_FeatureTypeForm.svelte
@@ -81,7 +81,6 @@
         columns: []
       }
     ];
-    syncLocalFeatureTypes(featureTypes);
     activeTabId = id;
     onChange(featureTypes);
   }
@@ -93,7 +92,6 @@
       targetEl,
       async () => {
         featureTypes = featureTypes.filter((featureType) => featureType.id !== id);
-        syncLocalFeatureTypes(featureTypes);
         if (activeTabId === id) {
           activeTabId = featureTypes.length > 1 ? featureTypes[0].id : undefined;
         }
@@ -120,60 +118,7 @@
       }
       return featureType;
     });
-    syncLocalFeatureTypes(featureTypes);
     return onChange(featureTypes);
-  }
-
-  function syncLocalFeatureTypes(nextFeatureTypes: FeatureType[]) {
-    if (!formState.metadata?.isoMetadata?.services) {
-      return;
-    }
-
-    let hasMatchedService = false;
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        services: formState.metadata.isoMetadata.services.map((entry: Service) => {
-          const isTargetService =
-            entry.id === service.id ||
-            entry.serviceIdentification === service.serviceIdentification;
-
-          if (!isTargetService) {
-            return entry;
-          }
-
-          hasMatchedService = true;
-          return {
-            ...entry,
-            featureTypes: nextFeatureTypes
-          };
-        })
-      }
-    };
-
-    if (hasMatchedService) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        services: formState.metadata.isoMetadata.services.map((entry: Service) => {
-          const hasFeatureTypeFromCurrentService = entry.featureTypes?.some((ft: FeatureType) =>
-            nextFeatureTypes.some((nextFt) => nextFt.id === ft.id)
-          );
-          if (!hasFeatureTypeFromCurrentService) {
-            return entry;
-          }
-          return {
-            ...entry,
-            featureTypes: nextFeatureTypes
-          };
-        })
-      }
-    };
   }
 </script>
 

--- a/src/lib/components/Form/service/63_ColumnsForm.svelte
+++ b/src/lib/components/Form/service/63_ColumnsForm.svelte
@@ -23,7 +23,7 @@
   export type ColumnsFormProps = {
     featureType: FeatureType;
     value?: ColumnInfo[];
-    onChange: (columns: ColumnInfo[], persist?: boolean) => Promise<Response>;
+    onChange: (columns: ColumnInfo[]) => Promise<Response>;
   };
 
   let { value: initialColumns, onChange, featureType }: ColumnsFormProps = $props();
@@ -101,7 +101,7 @@
     );
   }
 
-  function set(key: string, value: ColumnInfo[keyof ColumnInfo], persist?: boolean) {
+  function set(key: string, value: ColumnInfo[keyof ColumnInfo]) {
     columns = columns.map((column) => {
       if (column.id === activeTabId) {
         return {
@@ -111,7 +111,7 @@
       }
       return column;
     });
-    return onChange(columns, persist);
+    return onChange(columns);
   }
 </script>
 
@@ -166,18 +166,9 @@
     </nav>
     <div class="content">
       {#if activeTabId && activeColumn}
-        <AttributeName_64
-          value={activeColumn?.name}
-          onChange={(name, persist) => set('name', name, persist)}
-        />
-        <AttributeAlias_65
-          value={activeColumn?.alias}
-          onChange={(alias, persist) => set('alias', alias, persist)}
-        />
-        <AttributeDatatype_66
-          value={activeColumn?.type}
-          onChange={(type, persist) => set('type', type, persist)}
-        />
+        <AttributeName_64 value={activeColumn?.name} onChange={(name) => set('name', name)} />
+        <AttributeAlias_65 value={activeColumn?.alias} onChange={(alias) => set('alias', alias)} />
+        <AttributeDatatype_66 value={activeColumn?.type} onChange={(type) => set('type', type)} />
       {/if}
     </div>
   </fieldset>

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -30,12 +30,7 @@
   let hasDuplicatedValue = $state<boolean>(false);
   const isDuplicateServiceId = (nextValue: string) => {
     const allServices = getValue<Service[]>('isoMetadata.services') || [];
-    return allServices.some(
-      (entry) =>
-        entry.id !== service.id &&
-        entry.workspace === nextValue &&
-        entry.serviceType === service.serviceType
-    );
+    return allServices.some((entry) => entry.id !== service.id && entry.workspace === nextValue);
   };
   const isInvalidWorkspace = (nextValue: string) => {
     const nextValidation = fieldConfig?.validator(nextValue, {

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -53,6 +53,13 @@
         hasDuplicatedValue = false;
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+        const newValidationResult = fieldConfig?.validator(newValue, {
+          ['PARENT_VALUE']: service,
+          ['HIGHEST_ROLE']: highestRole
+        });
+        if (newValidationResult?.valid === false) {
+          return;
+        }
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -15,10 +15,6 @@
   };
 
   let { value, service, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
@@ -33,7 +29,7 @@
         helpText: 'Der angegebene Identifikator ist bereits vergeben.'
       };
     }
-    return fieldConfig?.validator(localValue, {
+    return fieldConfig?.validator(value, {
       ['PARENT_VALUE']: service,
       ['HIGHEST_ROLE']: highestRole
     });
@@ -46,21 +42,12 @@
   <div class="service-id-field">
     <TextInput
       label={t('45_ServiceWorkspace.label')}
-      value={localValue}
+      {value}
       {fieldConfig}
       {validationResult}
       onchange={async (e: Event) => {
         hasDuplicatedValue = false;
-        const newValue = (e.target as HTMLInputElement).value;
-        localValue = newValue;
-        const newValidationResult = fieldConfig?.validator(newValue, {
-          ['PARENT_VALUE']: service,
-          ['HIGHEST_ROLE']: highestRole
-        });
-        if (newValidationResult?.valid === false) {
-          return;
-        }
-        const response = await onChange(newValue);
+        const response = await onChange((e.target as HTMLInputElement).value);
         if (response.ok) {
           showCheckmark = true;
         } else if (response.status === 409) {

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -2,7 +2,6 @@
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import type { Service } from '$lib/models/metadata';
   import { MetadataService } from '$lib/services/MetadataService';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
   import { getHighestRole } from '$lib/util';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
@@ -12,7 +11,7 @@
   export type ComponentProps = {
     value?: Service['workspace'];
     service: Service;
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, service, onChange }: ComponentProps = $props();
@@ -23,22 +22,10 @@
 
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
-  const { getValue } = getFormContext();
 
   const HELP_KEY = 'isoMetadata.services.workspace';
   const fieldConfig = MetadataService.getFieldConfig(45);
   let hasDuplicatedValue = $state<boolean>(false);
-  const isDuplicateServiceId = (nextValue: string) => {
-    const allServices = getValue<Service[]>('isoMetadata.services') || [];
-    return allServices.some((entry) => entry.id !== service.id && entry.workspace === nextValue);
-  };
-  const isInvalidWorkspace = (nextValue: string) => {
-    const nextValidation = fieldConfig?.validator(nextValue, {
-      ['PARENT_VALUE']: service,
-      ['HIGHEST_ROLE']: highestRole
-    });
-    return hasDuplicatedValue || nextValidation?.valid === false;
-  };
   const validationResult = $derived.by(() => {
     if (hasDuplicatedValue) {
       return {
@@ -51,9 +38,6 @@
       ['HIGHEST_ROLE']: highestRole
     });
   });
-  $effect(() => {
-    hasDuplicatedValue = isDuplicateServiceId(localValue);
-  });
   let showCheckmark = $state(false);
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
 </script>
@@ -65,23 +49,15 @@
       value={localValue}
       {fieldConfig}
       {validationResult}
-      onchange={(e: Event) => {
+      onchange={async (e: Event) => {
+        hasDuplicatedValue = false;
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
-        hasDuplicatedValue = isDuplicateServiceId(newValue);
-        void onChange(newValue, false);
-      }}
-      onblur={async (e: Event) => {
-        const newValue = (e.target as HTMLInputElement).value;
-        hasDuplicatedValue = isDuplicateServiceId(newValue);
-        if (isInvalidWorkspace(newValue)) return;
-
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;
         } else if (response.status === 409) {
           hasDuplicatedValue = true;
-          void onChange(value || '', false);
         }
       }}
     />

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -61,6 +61,10 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      const nextValidation = fieldConfig?.validator(newValue, {
+        ['PARENT_VALUE']: service
+      });
+      if (nextValidation?.valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -13,7 +13,7 @@
   export type ComponentProps = {
     value?: Service['preview'];
     service: Service;
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, service, onChange }: ComponentProps = $props();
@@ -58,13 +58,9 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -17,14 +17,10 @@
   };
 
   let { value, service, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const fieldConfig = MetadataService.getFieldConfig(46);
   const validationResult = $derived(
-    fieldConfig?.validator(localValue, {
+    fieldConfig?.validator(value, {
       ['PARENT_VALUE']: service
     })
   );
@@ -40,10 +36,6 @@
 
   const getAutoFillValues = async () => {
     if (!metadataPreview) return;
-    const nextValidation = fieldConfig?.validator(metadataPreview, {
-      ['PARENT_VALUE']: service
-    });
-    if (nextValidation?.valid === false) return;
     const response = await onChange(metadataPreview);
     if (response.ok) {
       showCheckmark = true;
@@ -55,17 +47,11 @@
   <TextInput
     label={t('46_ServicePreview.label')}
     explanation={t('46_ServicePreview.explanation')}
-    value={localValue}
+    {value}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      const nextValidation = fieldConfig?.validator(newValue, {
-        ['PARENT_VALUE']: service
-      });
-      if (nextValidation?.valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
@@ -17,39 +17,22 @@
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
-  let localValue = $state(value);
-  $effect(() => {
-    localValue = value;
-  });
 
   const fieldConfig = MetadataService.getFieldConfig(47);
   const fieldConfigUrl = MetadataService.getFieldConfig(75);
   const fieldConfigFormat = MetadataService.getFieldConfig(76);
   const fieldConfigWidth = MetadataService.getFieldConfig(77);
   const fieldConfigHeight = MetadataService.getFieldConfig(78);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
-  const validationResultUrl = $derived(fieldConfigUrl?.validator(localValue?.url));
-  const validationResultFormat = $derived(fieldConfigFormat?.validator(localValue?.format));
-  const validationResultWidth = $derived(fieldConfigWidth?.validator(localValue?.width));
-  const validationResultHeight = $derived(fieldConfigHeight?.validator(localValue?.height));
+  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResultUrl = $derived(fieldConfigUrl?.validator(value?.url));
+  const validationResultFormat = $derived(fieldConfigFormat?.validator(value?.format));
+  const validationResultWidth = $derived(fieldConfigWidth?.validator(value?.width));
+  const validationResultHeight = $derived(fieldConfigHeight?.validator(value?.height));
   let showCheckmark = $state(false);
 
   const update = async (key: string, val: string | number) => {
-    localValue = {
-      ...localValue,
-      [key]: val
-    };
-    const fieldValidationMap: Record<string, { valid?: boolean } | undefined> = {
-      url: fieldConfigUrl?.validator(key === 'url' ? val : localValue?.url),
-      format: fieldConfigFormat?.validator(key === 'format' ? val : localValue?.format),
-      width: fieldConfigWidth?.validator(key === 'width' ? val : localValue?.width),
-      height: fieldConfigHeight?.validator(key === 'height' ? val : localValue?.height)
-    };
-    if (fieldValidationMap[key]?.valid === false) {
-      return;
-    }
     const response = await onChange({
-      ...localValue,
+      ...value,
       [key]: val
     });
     if (response.ok) {

--- a/src/lib/components/Form/service/Field/49_LayerTitle.svelte
+++ b/src/lib/components/Form/service/Field/49_LayerTitle.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: Layer['title'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -31,13 +31,9 @@
     {fieldConfig}
     {validationResult}
     maxlength={250}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/49_LayerTitle.svelte
+++ b/src/lib/components/Form/service/Field/49_LayerTitle.svelte
@@ -12,14 +12,10 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'clientMetadata.layers.title';
   const fieldConfig = MetadataService.getFieldConfig(49);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
 </script>
 
@@ -27,15 +23,12 @@
   <TextInput
     label={t('49_LayerTitle.label')}
     explanation={t('49_LayerTitle.explanation')}
-    value={localValue}
+    {value}
     {fieldConfig}
     {validationResult}
     maxlength={250}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/50_LayerName.svelte
+++ b/src/lib/components/Form/service/Field/50_LayerName.svelte
@@ -10,7 +10,7 @@
 
   export type ComponentProps = {
     value?: Layer['name'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -32,14 +32,9 @@
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
   let showCheckmark = $state(false);
 
-  const onChangeInternal = (e: Event) => {
+  const onChangeInternal = async (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
     localValue = newValue;
-    void onChange(newValue, false);
-  };
-
-  const onBlurInternal = async (e: Event) => {
-    const newValue = (e.target as HTMLInputElement).value;
     if (
       fieldConfig?.validator(newValue, {
         ['HIGHEST_ROLE']: highestRole
@@ -63,7 +58,6 @@
       {fieldConfig}
       {validationResult}
       onchange={onChangeInternal}
-      onblur={onBlurInternal}
     />
     <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>

--- a/src/lib/components/Form/service/Field/50_LayerName.svelte
+++ b/src/lib/components/Form/service/Field/50_LayerName.svelte
@@ -14,10 +14,6 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'clientMetadata.layers.name';
 
@@ -25,7 +21,7 @@
   const highestRole = $derived(getHighestRole(token));
   const fieldConfig = MetadataService.getFieldConfig(50);
   const validationResult = $derived(
-    fieldConfig?.validator(localValue, {
+    fieldConfig?.validator(value, {
       ['HIGHEST_ROLE']: highestRole
     })
   );
@@ -34,14 +30,6 @@
 
   const onChangeInternal = async (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
-    localValue = newValue;
-    if (
-      fieldConfig?.validator(newValue, {
-        ['HIGHEST_ROLE']: highestRole
-      }).valid === false
-    ) {
-      return;
-    }
     const response = await onChange(newValue);
     if (response.ok) {
       showCheckmark = true;
@@ -53,7 +41,7 @@
   <div class="layer-name-field">
     <TextInput
       label={t('50_LayerName.label')}
-      value={localValue}
+      {value}
       maxlength={100}
       {fieldConfig}
       {validationResult}

--- a/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
+++ b/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
@@ -10,7 +10,7 @@
 
   export type ComponentProps = {
     value?: Layer['styleName'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -33,14 +33,9 @@
   );
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
 
-  const onChangeInternal = (e: Event) => {
+  const onChangeInternal = async (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
     localValue = newValue;
-    void onChange(newValue, false);
-  };
-
-  const onBlurInternal = async (e: Event) => {
-    const newValue = (e.target as HTMLInputElement).value;
     if (
       fieldConfig?.validator(newValue, {
         ['HIGHEST_ROLE']: highestRole
@@ -64,7 +59,6 @@
       {fieldConfig}
       {validationResult}
       onchange={onChangeInternal}
-      onblur={onBlurInternal}
     />
     <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>

--- a/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
+++ b/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
@@ -14,10 +14,6 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'clientMetadata.layers.styleName';
   let showCheckmark = $state(false);
@@ -27,7 +23,7 @@
 
   const fieldConfig = MetadataService.getFieldConfig(51);
   const validationResult = $derived(
-    fieldConfig?.validator(localValue, {
+    fieldConfig?.validator(value, {
       ['HIGHEST_ROLE']: highestRole
     })
   );
@@ -35,14 +31,6 @@
 
   const onChangeInternal = async (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
-    localValue = newValue;
-    if (
-      fieldConfig?.validator(newValue, {
-        ['HIGHEST_ROLE']: highestRole
-      }).valid === false
-    ) {
-      return;
-    }
     const response = await onChange(newValue);
     if (response.ok) {
       showCheckmark = true;
@@ -54,7 +42,7 @@
   <div class="layer-style-name-field">
     <TextInput
       label={t('51_LayerStyleName.label')}
-      value={localValue}
+      {value}
       maxlength={100}
       {fieldConfig}
       {validationResult}

--- a/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
+++ b/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
@@ -18,10 +18,6 @@
   const HELP_KEY = 'clientMetadata.layers.styleTitle';
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
   let showCheckmark = $state(false);
 
   const { getValue } = getFormContext();
@@ -31,7 +27,7 @@
   const highestRole = $derived(getHighestRole(token));
   const fieldConfig = MetadataService.getFieldConfig(52);
   const validationResult = $derived(
-    fieldConfig?.validator(localValue, {
+    fieldConfig?.validator(value, {
       HIGHEST_ROLE: highestRole,
       'isoMetadata.metadataProfile': metadataProfile
     })
@@ -47,22 +43,12 @@
   <div class="layer-style-title-field">
     <TextInput
       label={t('52_LayerStyleTitle.label')}
-      value={localValue}
+      {value}
       maxlength={250}
       {fieldConfig}
       {validationResult}
       onchange={async (e: Event) => {
-        const newValue = (e.target as HTMLInputElement).value;
-        localValue = newValue;
-        if (
-          fieldConfig?.validator(newValue, {
-            HIGHEST_ROLE: highestRole,
-            'isoMetadata.metadataProfile': metadataProfile
-          }).valid === false
-        ) {
-          return;
-        }
-        const response = await onChange(newValue);
+        const response = await onChange((e.target as HTMLInputElement).value);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
+++ b/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
@@ -11,7 +11,7 @@
 
   export type ComponentProps = {
     value?: Layer['styleTitle'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   const PROFILE_KEY = 'isoMetadata.metadataProfile';
@@ -51,13 +51,9 @@
       maxlength={250}
       {fieldConfig}
       {validationResult}
-      onchange={(e: Event) => {
+      onchange={async (e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
-        void onChange(newValue, false);
-      }}
-      onblur={async (e: Event) => {
-        const newValue = (e.target as HTMLInputElement).value;
         if (
           fieldConfig?.validator(newValue, {
             HIGHEST_ROLE: highestRole,

--- a/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
@@ -12,30 +12,23 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'clientMetadata.layers.legendImage';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(53);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
 </script>
 
 <div class="layer-legend-image-field">
   <TextInput
     label={t('53_LayerLegendImage.label')}
     explanation={t('53_LayerLegendImage.explanation')}
-    value={localValue}
+    {value}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
@@ -31,12 +31,9 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/54_LayerDescription.svelte
+++ b/src/lib/components/Form/service/Field/54_LayerDescription.svelte
@@ -12,31 +12,24 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'clientMetadata.layers.shortDescription';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(54);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
 </script>
 
 <div class="layer-short-description-field">
   <TextAreaInput
     label={t('54_LayerDescription.label')}
     explanation={t('54_LayerDescription.explanation')}
-    value={localValue}
+    {value}
     maxlength={500}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/54_LayerDescription.svelte
+++ b/src/lib/components/Form/service/Field/54_LayerDescription.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: Layer['shortDescription'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -32,13 +32,9 @@
     maxlength={500}
     {fieldConfig}
     {validationResult}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
+++ b/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
@@ -12,30 +12,23 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'clientMetadata.layers.datasource';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(55);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
 </script>
 
 <div class="layer-short-description-field">
   <TextInput
     label={t('55_LayerDatasource.label')}
     explanation={t('55_LayerDatasource.explanation')}
-    value={localValue}
+    {value}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
+++ b/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
@@ -31,12 +31,9 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/58_ServiceType.svelte
+++ b/src/lib/components/Form/service/Field/58_ServiceType.svelte
@@ -12,13 +12,9 @@
     onChange: (newValue: ServiceType) => Promise<Response>;
   };
   let { value, onChange }: ServiceTypeProps = $props();
-  let localValue = $state(value);
-  $effect(() => {
-    localValue = value;
-  });
 
   const fieldConfig = MetadataService.getFieldConfig(58);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
   const HELP_KEY = 'isoMetadata.services.type';
 </script>
@@ -27,7 +23,7 @@
   <SelectInput
     label={t('58_ServiceType.label')}
     explanation={t('58_ServiceType.explanation')}
-    value={localValue}
+    {value}
     {fieldConfig}
     {validationResult}
     options={[
@@ -49,10 +45,7 @@
       }
     ]}
     onChange={async (value) => {
-      const newValue = value as ServiceType;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange(value as ServiceType);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -12,7 +12,7 @@
 
   export type ServiceTypeProps = {
     value: Service['title'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -52,13 +52,9 @@
     {fieldConfig}
     {validationResult}
     maxlength={250}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -55,6 +55,7 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -26,17 +26,11 @@
   const metadataTitle = $derived(getValue<string>(METADATA_TITLE_KEY, metadata));
 
   const fieldConfig = MetadataService.getFieldConfig(59);
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
 
   const getAutoFillValues = async () => {
     if (!metadataTitle) return;
-    if (fieldConfig?.validator(metadataTitle).valid === false) return;
-    localValue = metadataTitle;
     const response = await onChange(metadataTitle);
     if (response.ok) {
       showCheckmark = true;
@@ -48,15 +42,12 @@
   <TextInput
     label={t('59_ServiceTitle.label')}
     explanation={t('59_ServiceTitle.explanation')}
-    value={localValue}
+    {value}
     {fieldConfig}
     {validationResult}
     maxlength={250}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -12,7 +12,7 @@
 
   export type ServiceTypeProps = {
     value: Service['shortDescription'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value = $bindable(), onChange }: ServiceTypeProps = $props();
@@ -47,12 +47,7 @@
     {fieldConfig}
     {validationResult}
     rows={5}
-    onchange={(e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      value = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -30,7 +30,6 @@
 
   const getAutoFillValues = async () => {
     if (!metadataDescription) return;
-    if (fieldConfig?.validator(metadataDescription).valid === false) return;
     const response = await onChange(metadataDescription);
     if (response.ok) {
       showCheckmark = true;
@@ -48,9 +47,7 @@
     {validationResult}
     rows={5}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -49,6 +49,7 @@
     rows={5}
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
+      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -12,14 +12,10 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.title';
   const fieldConfig = MetadataService.getFieldConfig(61);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
 </script>
 
@@ -27,15 +23,12 @@
   <TextInput
     label={t('61_FeatureTypeTitle.label')}
     explanation={t('61_FeatureTypeTitle.explanation')}
-    value={localValue}
+    {value}
     maxlength={100}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: FeatureType['title'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -31,13 +31,9 @@
     maxlength={100}
     {fieldConfig}
     {validationResult}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -34,6 +34,7 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -14,7 +14,7 @@
   export type ComponentProps = {
     value?: FeatureType['name'];
     featureType: FeatureType;
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, featureType, onChange }: ComponentProps = $props();
@@ -48,13 +48,9 @@
       maxlength={100}
       {fieldConfig}
       {validationResult}
-      onchange={(e: Event) => {
+      onchange={async (e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
-        void onChange(newValue, false);
-      }}
-      onblur={async (e: Event) => {
-        const newValue = (e.target as HTMLInputElement).value;
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -18,10 +18,6 @@
   };
 
   let { value, featureType, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
@@ -30,7 +26,7 @@
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formState.metadata);
   const validationResult = $derived(
-    ValidationService.validateField(fieldConfig, localValue, {
+    ValidationService.validateField(fieldConfig, value, {
       HIGHEST_ROLE: highestRole,
       PARENT_VALUE: featureType,
       metadata
@@ -44,20 +40,12 @@
   <div class="featuretype-name-field">
     <TextInput
       label={t('62_FeatureTypeName.label')}
-      value={localValue}
+      {value}
       maxlength={100}
       {fieldConfig}
       {validationResult}
       onchange={async (e: Event) => {
-        const newValue = (e.target as HTMLInputElement).value;
-        localValue = newValue;
-        const nextValidation = ValidationService.validateField(fieldConfig, newValue, {
-          HIGHEST_ROLE: highestRole,
-          PARENT_VALUE: featureType,
-          metadata
-        });
-        if (nextValidation.valid === false) return;
-        const response = await onChange(newValue);
+        const response = await onChange((e.target as HTMLInputElement).value);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -51,6 +51,12 @@
       onchange={async (e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+        const nextValidation = ValidationService.validateField(fieldConfig, newValue, {
+          HIGHEST_ROLE: highestRole,
+          PARENT_VALUE: featureType,
+          metadata
+        });
+        if (nextValidation.valid === false) return;
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -33,6 +33,7 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: ColumnInfo['name'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -30,13 +30,9 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -12,14 +12,10 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.columns.name';
   const fieldConfig = MetadataService.getFieldConfig(64);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
 </script>
 
@@ -27,14 +23,11 @@
   <TextInput
     label={t('64_AttributeName.label')}
     explanation={t('64_AttributeName.explanation')}
-    value={localValue}
+    {value}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -33,6 +33,7 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: ColumnInfo['alias'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -30,13 +30,9 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -12,14 +12,10 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.columns.alias';
   const fieldConfig = MetadataService.getFieldConfig(65);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
 </script>
 
@@ -27,14 +23,11 @@
   <TextInput
     label={t('65_AttributeAlias.label')}
     explanation={t('65_AttributeAlias.explanation')}
-    value={localValue}
+    {value}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -11,7 +11,7 @@
 
   export type ServiceTypeProps = {
     value?: ColumnInfo['type'];
-    onChange: (newValue: ColumnInfo['type']) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -55,9 +55,8 @@
       onChange={async (newValue) => {
         const typedValue = newValue as ColumnInfo['type'];
         localValue = typedValue;
-        if (typedValue === undefined) {
-          return;
-        }
+        if (!typedValue) return;
+        if (fieldConfig?.validator(typedValue).valid === false) return;
         const response = await onChange(typedValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -15,17 +15,13 @@
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
-  let localValue = $state(value);
-  $effect(() => {
-    localValue = value;
-  });
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.columns.type';
   const fieldConfig = MetadataService.getFieldConfig(66);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
   let showCheckmark = $state(false);
 
   const options: Option[] = [
@@ -50,14 +46,10 @@
       label={t('66_AttributeDatatype.label')}
       {fieldConfig}
       {validationResult}
-      value={localValue}
+      {value}
       {options}
       onChange={async (newValue) => {
-        const typedValue = newValue as ColumnInfo['type'];
-        localValue = typedValue;
-        if (!typedValue) return;
-        if (fieldConfig?.validator(typedValue).valid === false) return;
-        const response = await onChange(typedValue);
+        const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -11,7 +11,7 @@
 
   export type ServiceTypeProps = {
     value?: ColumnInfo['type'];
-    onChange: (newValue: ColumnInfo['type'], persist?: boolean) => Promise<Response>;
+    onChange: (newValue: ColumnInfo['type']) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -55,7 +55,10 @@
       onChange={async (newValue) => {
         const typedValue = newValue as ColumnInfo['type'];
         localValue = typedValue;
-        const response = await onChange(typedValue, typedValue !== undefined);
+        if (typedValue === undefined) {
+          return;
+        }
+        const response = await onChange(typedValue);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
+++ b/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
@@ -14,16 +14,12 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'clientMetadata.layers.secondaryDatasource';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(68);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
 
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
@@ -34,14 +30,11 @@
   <div class="layer-short-description-field">
     <TextInput
       label={t('68_LayerSecondaryDatasource.label')}
-      value={localValue}
+      {value}
       {fieldConfig}
       {validationResult}
       onchange={async (e: Event) => {
-        const newValue = (e.target as HTMLInputElement).value;
-        localValue = newValue;
-        if (fieldConfig?.validator(newValue).valid === false) return;
-        const response = await onChange(newValue);
+        const response = await onChange((e.target as HTMLInputElement).value);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
+++ b/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
@@ -37,12 +37,9 @@
       value={localValue}
       {fieldConfig}
       {validationResult}
-      onchange={(e: Event) => {
+      onchange={async (e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
-      }}
-      onblur={async (e: Event) => {
-        const newValue = (e.target as HTMLInputElement).value;
         if (fieldConfig?.validator(newValue).valid === false) return;
         const response = await onChange(newValue);
         if (response.ok) {

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -9,7 +9,7 @@
 
   export type ComponentProps = {
     value?: FeatureType['shortDescription'];
-    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
+    onChange: (newValue: string) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -33,13 +33,9 @@
     maxlength={500}
     {fieldConfig}
     {validationResult}
-    onchange={(e: Event) => {
+    onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
-    }}
-    onblur={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -13,31 +13,24 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.shortDescription';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(69);
-  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResult = $derived(fieldConfig?.validator(value));
 </script>
 
 <div class="featuretype-short-description-field">
   <TextAreaInput
     label={t('69_FeatureTypeDescription.label')}
     explanation={t('69_FeatureTypeDescription.explanation')}
-    value={localValue}
+    {value}
     maxlength={500}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const newValue = (e.target as HTMLInputElement).value;
-      localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
-      const response = await onChange(newValue);
+      const response = await onChange((e.target as HTMLInputElement).value);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -36,6 +36,7 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/validation.ts
+++ b/src/lib/components/Form/service/validation.ts
@@ -192,12 +192,7 @@ export function validateService(
   const allServices = (context?.metadata?.isoMetadata?.services || []) as Service[];
   const hasDuplicateWorkspace =
     !!service?.workspace &&
-    allServices.some(
-      (entry) =>
-        entry.id !== service.id &&
-        entry.workspace === service.workspace &&
-        entry.serviceType === service.serviceType
-    );
+    allServices.some((entry) => entry.id !== service.id && entry.workspace === service.workspace);
   const featureTypesRequired = service.serviceType === 'WFS';
   const layersRequired = ['WMS', 'WMTS'].includes(service?.serviceType || '');
   let hasInvalidLayersFlag = false;

--- a/src/lib/components/Form/service/validation.ts
+++ b/src/lib/components/Form/service/validation.ts
@@ -189,10 +189,6 @@ export function validateService(
   ];
 
   const fieldsValid = validateFields(validations);
-  const allServices = (context?.metadata?.isoMetadata?.services || []) as Service[];
-  const hasDuplicateWorkspace =
-    !!service?.workspace &&
-    allServices.some((entry) => entry.id !== service.id && entry.workspace === service.workspace);
   const featureTypesRequired = service.serviceType === 'WFS';
   const layersRequired = ['WMS', 'WMTS'].includes(service?.serviceType || '');
   let hasInvalidLayersFlag = false;
@@ -206,7 +202,7 @@ export function validateService(
   }
 
   return {
-    hasInvalidFields: !fieldsValid || hasDuplicateWorkspace,
+    hasInvalidFields: !fieldsValid,
     hasInvalidLayers: hasInvalidLayersFlag,
     hasInvalidFeatureTypes: hasInvalidFeatureTypesFlag
   };

--- a/src/lib/services/MetadataService.ts
+++ b/src/lib/services/MetadataService.ts
@@ -102,25 +102,12 @@ export class MetadataService {
   /**
    * Persists a metadata value to the server.
    * Handles server communication, data invalidation, error handling, and user notifications.
-   * For required fields with empty values, returns a local 422 response instead of
-   * sending a request to the backend.
    *
    * @param key - Path to the value to persist (e.g., 'isoMetadata.title')
    * @param value - The value to persist
-   * @returns The server response, or a local 422 validation response
+   * @returns The server response
    */
   static async persistValue(key: string, value: unknown) {
-    const fieldConfig = FieldConfigs.find((config) => config.key === key);
-    const isEmptyValue =
-      value === null ||
-      value === undefined ||
-      value === '' ||
-      (Array.isArray(value) && value.length === 0);
-
-    if (fieldConfig?.required && isEmptyValue) {
-      return new Response(null, { status: 422, statusText: 'Validation failed' });
-    }
-
     return MetadataUpdateService.pushToQueue(key, value);
   }
 

--- a/src/lib/services/ValidationService.ts
+++ b/src/lib/services/ValidationService.ts
@@ -293,10 +293,7 @@ export class ValidationService {
         const parentConfig = FieldConfigs.find(({ key }) => key === field.collectionKey);
         if (!parentConfig) return;
 
-        const parentCollection =
-          field.collectionKey === 'clientMetadata.layers'
-            ? (MetadataService.getValue<Service[]>('isoMetadata.services', metadata!) as any[])
-            : (MetadataService.getAllValues(parentConfig.key, metadata!) as any[]);
+        const parentCollection = MetadataService.getAllValues(parentConfig.key, metadata!) as any[];
 
         // If parent collection is empty or not an array, skip validation
         if (!Array.isArray(parentCollection) || parentCollection.length === 0) {

--- a/src/lib/services/ValidationService.ts
+++ b/src/lib/services/ValidationService.ts
@@ -246,9 +246,6 @@ export class ValidationService {
                 // No service found for this layer, skip it
                 continue;
               }
-              if (layerService.id !== v.id) {
-                continue;
-              }
 
               const fieldPath = `clientMetadata.layers['${serviceId}']`;
               // handle the 'clientMetadata.layers' collection itself


### PR DESCRIPTION
This PR reverts changes from the following previous PRs:

- https://github.com/gdi-be/mde-client/pull/286
- https://github.com/gdi-be/mde-client/pull/284
- https://github.com/gdi-be/mde-client/pull/283
- https://github.com/gdi-be/mde-client/pull/282 (partly)
- https://github.com/gdi-be/mde-client/pull/279

In general, invalid data is no longer saved to the database. The fact that fieldsets are now only saved as a group when all required fields have been filled in, rather than each field being saved individually, is unintended and interferes with standard workflows.  
These changes are therefore being temporarily removed from the update (via git revert) so that they can be easily restored later.