### PR TITLE
Fix progress bar in the Classification tab (#29805)

### DIFF
--- a/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
+++ b/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
@@ -4,7 +4,6 @@
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import { page } from '$app/state';
-  import { ValidationService } from '$lib/services/ValidationService';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.termsOfUseSource';
@@ -23,7 +22,12 @@
 
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(26);
-  let validationResult = $derived(ValidationService.validateField(fieldConfig, value));
+  let validationResult = $derived(
+    fieldConfig.validator(value, {
+      'isoMetadata.termsOfUseId': termsOfUseId,
+      'isoMetadata.privacy': privacy
+    })
+  );
 
   const onBlur = async () => {
     const response = await MetadataService.persistValue(KEY, value);

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -526,10 +526,11 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
   {
     profileId: 26,
     key: 'isoMetadata.termsOfUseSource',
-    extraParams: ['isoMetadata.termsOfUseId'],
+    extraParams: ['isoMetadata.termsOfUseId', 'isoMetadata.privacy'],
     validator: (val, extraParams) => {
       const termsOfUseId = extraParams?.['isoMetadata.termsOfUseId'];
-      const isRequired = termsOfUseId !== 1;
+      const privacy = extraParams?.['isoMetadata.privacy'];
+      const isRequired = privacy === 'NONE' && !!termsOfUseId && termsOfUseId !== 1;
       if (isRequired && !isDefined(val)) {
         return {
           valid: false,

--- a/tests/ValidationService.spec.ts
+++ b/tests/ValidationService.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { ValidationService, type ValidationContext } from '$lib/services/ValidationService';
 import metadata1 from './fixtures/metadata1';
 import type { FullFieldConfig } from '../src/lib/components/Form/FieldsConfig';
+import type { MetadataCollection } from '../src/lib/models/metadata';
 
 describe('ValidationService', () => {
   describe('canEditField', () => {
@@ -189,6 +190,23 @@ describe('ValidationService', () => {
       // @ts-expect-error - Testing behavior when no role is provided
       const result = ValidationService.allFieldsValid(metadata1, undefined);
       expect(result).toBe(true);
+    });
+  });
+
+  describe('getProgress', () => {
+    test('should ignore termsOfUseSource when the field is not visible', () => {
+      const metadata = {
+        ...metadata1,
+        isoMetadata: {
+          ...metadata1.isoMetadata,
+          privacy: 'PERSONAL_DATA',
+          termsOfUseId: 2,
+          termsOfUseSource: undefined
+        }
+      } as MetadataCollection;
+
+      const result = ValidationService.getProgress(metadata, 'MdeAdministrator', 'classification');
+      expect(result.progress).toBe(1);
     });
   });
 });


### PR DESCRIPTION
See also [#29805](https://redmine.intranet.terrestris.de/issues/29805).

This PR fixes the validation logic for the `termsOfUseSource` field. The field is now treated as required only when it is actually visible, based on the selected privacy setting and terms of use.