### PR TITLE
Restore updated version (#29089 / #29500 )

### DIFF
--- a/src/lib/components/Form/Field/01_TitleField.svelte
+++ b/src/lib/components/Form/Field/01_TitleField.svelte
@@ -1,19 +1,43 @@
 <script lang="ts">
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
+  import {
+    FORMSTATE_CONTEXT,
+    getFormContext,
+    type FormState
+  } from '$lib/context/FormContext.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import { page } from '$app/state';
+  import { getContext } from 'svelte';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.title';
 
   const formContext = $derived(getFormContext());
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(formContext.getValue<string>(KEY));
   let value = $derived(valueFromData ?? '');
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(1);
   let validationResult = $derived(fieldConfig?.validator(value));
+
+  $effect(() => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    if (formState.metadata.isoMetadata.title === value) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        title: value
+      }
+    };
+  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/01_TitleField.svelte
+++ b/src/lib/components/Form/Field/01_TitleField.svelte
@@ -16,6 +16,7 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onBlur = async () => {
+    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -1,20 +1,44 @@
 <script lang="ts">
   import type { ValidationResult } from '../FieldsConfig';
   import FieldTools from '../FieldTools.svelte';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
+  import {
+    FORMSTATE_CONTEXT,
+    getFormContext,
+    type FormState
+  } from '$lib/context/FormContext.svelte';
   import TextAreaInput from '../Inputs/TextAreaInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import { page } from '$app/state';
+  import { getContext } from 'svelte';
   const t = $derived(page.data.t);
 
   const KEY = 'isoMetadata.description';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $derived(valueFromData ?? '');
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(2);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+
+  $effect(() => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    if (formState.metadata.isoMetadata.description === value) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        description: value
+      }
+    };
+  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -17,6 +17,7 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
+    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -17,7 +17,15 @@
   const { getValue } = getFormContext();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
-  let value = $derived(valueFromData ?? '');
+  let value = $state('');
+  let hasUnsavedLocalChange = $state(false);
+  $effect(() => {
+    if (hasUnsavedLocalChange) {
+      return;
+    }
+    value = valueFromData || '';
+  });
+
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(2);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
@@ -44,6 +52,7 @@
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -53,6 +62,9 @@
   <TextAreaInput
     bind:value
     maxlength={500}
+    onchange={() => {
+      hasUnsavedLocalChange = true;
+    }}
     onblur={onBlur}
     label={t('02_DescriptionField.label')}
     explanation={t('02_DescriptionField.explanation')}

--- a/src/lib/components/Form/Field/04_PrivacyField.svelte
+++ b/src/lib/components/Form/Field/04_PrivacyField.svelte
@@ -4,6 +4,7 @@
   import RadioInput from '../Inputs/RadioInput.svelte';
   import type { ValidationResult } from '../FieldsConfig';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { MetadataUpdateService } from '$lib/services/MetadataUpdateService';
   import type { Option } from '$lib/models/form';
   import { toast } from 'svelte-french-toast';
   import { page } from '$app/state';
@@ -27,7 +28,7 @@
       showCheckmark = true;
 
       // delete terms of use value if privacy is changed
-      await MetadataService.persistValue(TERMS_OF_USE_KEY, null);
+      await MetadataUpdateService.pushToQueue(TERMS_OF_USE_KEY, null);
     }
   };
 

--- a/src/lib/components/Form/Field/04_PrivacyField.svelte
+++ b/src/lib/components/Form/Field/04_PrivacyField.svelte
@@ -21,6 +21,7 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue: string) => {
+    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/05_MetadataProfileField.svelte
+++ b/src/lib/components/Form/Field/05_MetadataProfileField.svelte
@@ -36,6 +36,7 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue?: string) => {
+    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
+++ b/src/lib/components/Form/Field/06_HighValueDatasetField.svelte
@@ -41,6 +41,13 @@
   };
 
   const onSelectionChange = async (newSelection?: string[]) => {
+    if (
+      categoryFieldConfig?.validator(newSelection, {
+        'isoMetadata.highValueDataset': checkedValue
+      }).valid === false
+    ) {
+      return;
+    }
     const response = await MetadataService.persistValue(CATEGORY_KEY, newSelection);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/07_AnnexThemeField.svelte
+++ b/src/lib/components/Form/Field/07_AnnexThemeField.svelte
@@ -36,6 +36,7 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onChange = async (newValue?: string[]) => {
+    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/09_CreatedField.svelte
+++ b/src/lib/components/Form/Field/09_CreatedField.svelte
@@ -33,6 +33,7 @@
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
+    if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
       inputValue ? new Date(inputValue).toISOString() : null

--- a/src/lib/components/Form/Field/09_CreatedField.svelte
+++ b/src/lib/components/Form/Field/09_CreatedField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.created';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   let initialized = false;
@@ -30,9 +30,32 @@
   const fieldConfig = MetadataService.getFieldConfig<string>(9);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
+  const onChange = (evt: Event) => {
+    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
+    value = inputValue;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          created: inputValue ? new Date(inputValue).toISOString() : null
+        }
+      };
+    }
+  };
+
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          created: inputValue ? new Date(inputValue).toISOString() : null
+        }
+      };
+    }
     if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
@@ -51,6 +74,7 @@
     label={t('09_CreatedField.label')}
     explanation={t('09_CreatedField.explanation')}
     {fieldConfig}
+    onchange={onChange}
     onblur={onBlur}
     {validationResult}
   />

--- a/src/lib/components/Form/Field/10_PublishedField.svelte
+++ b/src/lib/components/Form/Field/10_PublishedField.svelte
@@ -33,6 +33,8 @@
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
+    if (fieldConfig?.required && !inputValue) return;
+    if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
       inputValue ? new Date(inputValue).toISOString() : null

--- a/src/lib/components/Form/Field/10_PublishedField.svelte
+++ b/src/lib/components/Form/Field/10_PublishedField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.published';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $state('');
   let initialized = false;
@@ -29,18 +29,45 @@
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(10);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+  const toIsoDate = (inputValue: string) =>
+    inputValue ? new Date(inputValue).toISOString() : null;
+  let hasUnsavedLocalChange = $state(false);
+
+  $effect(() => {
+    if (!hasUnsavedLocalChange) {
+      return;
+    }
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+    const localValue = toIsoDate(value);
+    if (formState.metadata.isoMetadata.published === localValue) {
+      return;
+    }
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        published: localValue
+      }
+    };
+  });
+
+  const onChange = (evt: Event) => {
+    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
+    value = inputValue;
+    hasUnsavedLocalChange = true;
+  };
 
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
     if (fieldConfig?.required && !inputValue) return;
     if (fieldConfig?.validator(inputValue).valid === false) return;
-    const response = await MetadataService.persistValue(
-      KEY,
-      inputValue ? new Date(inputValue).toISOString() : null
-    );
+    const response = await MetadataService.persistValue(KEY, toIsoDate(inputValue));
 
     if (response.ok) {
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -53,6 +80,7 @@
     label={t('10_PublishedField.label')}
     explanation={t('10_PublishedField.explanation')}
     {fieldConfig}
+    onchange={onChange}
     onblur={onBlur}
     {validationResult}
   />

--- a/src/lib/components/Form/Field/11_LastUpdatedField.svelte
+++ b/src/lib/components/Form/Field/11_LastUpdatedField.svelte
@@ -41,6 +41,7 @@
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
+    if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
       inputValue ? new Date(inputValue).toISOString() : null

--- a/src/lib/components/Form/Field/11_LastUpdatedField.svelte
+++ b/src/lib/components/Form/Field/11_LastUpdatedField.svelte
@@ -17,7 +17,7 @@
   const formContext = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formContext.metadata);
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY, metadata));
   let value = $state('');
   let initialized = false;
@@ -38,9 +38,32 @@
 
   let showCheckmark = $state(false);
 
+  const onChange = (evt: Event) => {
+    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
+    value = inputValue;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          modified: inputValue ? new Date(inputValue).toISOString() : null
+        }
+      };
+    }
+  };
+
   const onBlur = async (evt: FocusEvent) => {
     const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
     value = inputValue;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          modified: inputValue ? new Date(inputValue).toISOString() : null
+        }
+      };
+    }
     if (fieldConfig?.validator(inputValue).valid === false) return;
     const response = await MetadataService.persistValue(
       KEY,
@@ -58,6 +81,7 @@
     key={KEY}
     label={t('11_LastUpdatedField.label')}
     explanation={t('11_LastUpdatedField.explanation')}
+    onchange={onChange}
     onblur={onBlur}
     {fieldConfig}
     {validationResult}

--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -52,6 +52,9 @@
   let toValidationResult = $derived(toFieldConfig?.validator(endValue, [startValue]));
 
   const onBlur = async (key: string) => {
+    if (hasInvalidFields) {
+      return;
+    }
     const value = key === FROM_KEY ? startValue : endValue!;
     const valueToPersist = value ? new Date(value).toISOString() : null;
     const response = await MetadataService.persistValue(key, valueToPersist);

--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -11,7 +11,7 @@
   const FROM_KEY = 'isoMetadata.validFrom';
   const TO_KEY = 'isoMetadata.validTo';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const startValueFromData = $derived(getValue<string>(FROM_KEY));
   let startValue = $state('');
   let startInitialized = false;
@@ -52,6 +52,16 @@
   let toValidationResult = $derived(toFieldConfig?.validator(endValue, [startValue]));
 
   const onBlur = async (key: string) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          validFrom: startValue ? new Date(startValue).toISOString() : null,
+          validTo: endValue ? new Date(endValue).toISOString() : null
+        }
+      };
+    }
     if (hasInvalidFields) {
       return;
     }
@@ -62,6 +72,25 @@
       showCheckmark = true;
     }
     invalidateAll();
+  };
+
+  const onChange = (key: string, evt: Event) => {
+    const inputValue = (evt.currentTarget as HTMLInputElement | null)?.value ?? '';
+    if (key === FROM_KEY) {
+      startValue = inputValue;
+    } else {
+      endValue = inputValue;
+    }
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          validFrom: startValue ? new Date(startValue).toISOString() : null,
+          validTo: endValue ? new Date(endValue).toISOString() : null
+        }
+      };
+    }
   };
 
   let hasInvalidFields = $derived.by(() => {
@@ -87,6 +116,7 @@
       <DateInput
         bind:value={startValue}
         label={t('12_ValidityRangeField.label_from')}
+        onchange={(evt) => onChange(FROM_KEY, evt)}
         onblur={() => onBlur(FROM_KEY)}
         fieldConfig={fromFieldConfig}
         validationResult={fromValidationResult}
@@ -94,6 +124,7 @@
       <DateInput
         bind:value={endValue}
         label={t('12_ValidityRangeField.label_to')}
+        onchange={(evt) => onChange(TO_KEY, evt)}
         onblur={() => onBlur(TO_KEY)}
         fieldConfig={toFieldConfig}
         validationResult={toValidationResult}

--- a/src/lib/components/Form/Field/13_TopicCategory.svelte
+++ b/src/lib/components/Form/Field/13_TopicCategory.svelte
@@ -31,6 +31,7 @@
   let disabled = $derived(!!annexValue?.length && profileValue !== 'ISO');
 
   const onChange = async (newValue?: string[]) => {
+    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
+++ b/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
@@ -36,6 +36,7 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue?: string) => {
+    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
+++ b/src/lib/components/Form/Field/14_MaintenanceFrequencyField.svelte
@@ -27,7 +27,7 @@
     { key: 'unknown', label: 'unbekannt' }
   ];
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $derived(valueFromData ?? '');
 
@@ -36,6 +36,15 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onChange = async (newValue?: string) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          maintenanceFrequency: newValue as MaintenanceFrequency
+        }
+      };
+    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/Field/15_KeywordsField.svelte
+++ b/src/lib/components/Form/Field/15_KeywordsField.svelte
@@ -96,6 +96,7 @@
   };
 
   const persistKeywords = async () => {
+    if (validationResult?.valid === false) return;
     const keywords: Keywords = valueFromData || {
       default: []
     };

--- a/src/lib/components/Form/Field/15_KeywordsField.svelte
+++ b/src/lib/components/Form/Field/15_KeywordsField.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import { onMount } from 'svelte';
+  import { getContext } from 'svelte';
   import Chip, { Set as ChipSet, Text, TrailingIcon } from '@smui/chips';
   import Autocomplete from '@smui-extra/autocomplete';
   import Dialog, { Actions, Content, Title } from '@smui/dialog';
@@ -23,8 +25,9 @@
   let { metadataid } = page.params;
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
+  let value = $state<string[]>([]);
   const valueFromData = $derived(getValue<Keywords>(KEY));
-  let value = $derived<string[]>(valueFromData?.default?.map((entry) => entry.keyword) || []);
 
   let showCheckmark = $state(false);
   let autoKeywords = $state<string[]>([]);
@@ -32,7 +35,10 @@
   let uniqueKeywords = $derived(Array.from(new Set([...autoKeywords, ...value])));
   let searchValue = $state('');
   const fieldConfig = MetadataService.getFieldConfig<Keywords>(15);
-  let validationResult = $derived(fieldConfig?.validator(valueFromData));
+  const toKeywords = (keywords: string[]): Keywords => ({
+    default: keywords.map((entry) => ({ keyword: entry }))
+  });
+  let validationResult = $derived(fieldConfig?.validator(toKeywords(value)));
 
   let dialogOpen = $state(false);
   let newKeyword = $state('');
@@ -96,14 +102,19 @@
   };
 
   const persistKeywords = async () => {
+    const keywords: Keywords = toKeywords(value);
+
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          keywords
+        }
+      };
+    }
+
     if (validationResult?.valid === false) return;
-    const keywords: Keywords = valueFromData || {
-      default: []
-    };
-    keywords.default = value
-      // filter autokeywords from value to avoid duplicates
-      .filter((kw) => !autoKeywords.includes(kw))
-      .map((entry) => ({ keyword: entry }));
 
     const response = await MetadataService.persistValue(KEY, keywords);
     if (response.ok) {

--- a/src/lib/components/Form/Field/15_KeywordsField.svelte
+++ b/src/lib/components/Form/Field/15_KeywordsField.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
   import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
@@ -24,10 +23,8 @@
   let containerElement = $state<HTMLDivElement>();
   let { metadataid } = page.params;
 
-  const { getValue } = getFormContext();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   let value = $state<string[]>([]);
-  const valueFromData = $derived(getValue<Keywords>(KEY));
 
   let showCheckmark = $state(false);
   let autoKeywords = $state<string[]>([]);

--- a/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
@@ -9,7 +9,7 @@
   const t = $derived(page.data.t);
   const KEY = 'technicalMetadata.deliveredCrs';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $derived(valueFromData ?? '');
 
@@ -18,6 +18,15 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
+    if (formState.metadata?.technicalMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        technicalMetadata: {
+          ...formState.metadata.technicalMetadata,
+          deliveredCrs: value
+        }
+      };
+    }
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {

--- a/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/16_DeliveredCoordinateSystemField.svelte
@@ -18,6 +18,7 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
+    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
@@ -26,6 +26,7 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onSelectionChange = async (newValue?: string) => {
+    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
+++ b/src/lib/components/Form/Field/17_CoordinateSystemField.svelte
@@ -17,7 +17,7 @@
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $derived(valueFromData ?? '');
 
@@ -26,6 +26,15 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onSelectionChange = async (newValue?: string) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          crs: newValue as string
+        }
+      };
+    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/Field/18_ExtentField.svelte
+++ b/src/lib/components/Form/Field/18_ExtentField.svelte
@@ -115,6 +115,9 @@
   };
 
   const sendValue = async () => {
+    if (hasInvalidFields) {
+      return;
+    }
     const response = await MetadataService.persistValue(KEY, value4326);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/18_ExtentField.svelte
+++ b/src/lib/components/Form/Field/18_ExtentField.svelte
@@ -7,7 +7,7 @@
   import Button, { Icon, Label } from '@smui/button';
   import SelectInput from '../Inputs/SelectInput.svelte';
   import { getHighestRole, registerCRSCodes, transformExtent } from '$lib/util';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { toast } from 'svelte-french-toast';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import type { CRSOption } from '$lib/models/api';
@@ -158,8 +158,9 @@
             type="button"
             variant={matchingOption?.title === option.title ? 'raised' : 'text'}
             title={option.title}
-            onclick={() => {
+            onclick={async () => {
               value4326 = option.value;
+              await tick();
               sendValue();
             }}
           >

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -84,6 +84,9 @@
   };
 
   const persistContacts = async (evt?: FocusEvent) => {
+    if (hasInvalidFields) {
+      return;
+    }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -2,6 +2,7 @@
   import type { Contact, Contacts } from '$lib/models/metadata';
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
@@ -12,6 +13,7 @@
   import { page } from '$app/state';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
+  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -21,6 +23,7 @@
   const KEY = 'isoMetadata.pointsOfContact';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   let contacts = $state<Contact[]>([]);
   const valueFromData = $derived(getValue<Contacts>(KEY));
 
@@ -84,6 +87,16 @@
   };
 
   const persistContacts = async (evt?: FocusEvent) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          pointsOfContact: contacts
+        }
+      };
+    }
+
     if (hasInvalidFields) {
       return;
     }

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -29,10 +29,14 @@
 
   // important that this is not a state
   let previousValueAsString: string;
+  let hasUnsavedLocalChange = $state(false);
 
   const popconfirm = $derived(getPopconfirm());
 
   $effect(() => {
+    if (hasUnsavedLocalChange) {
+      return;
+    }
     // this check prevents rerendering if nothing has actually changed
     const newValueAsString = JSON.stringify(valueFromData);
     if (
@@ -105,6 +109,7 @@
     const focusedElement = evt?.relatedTarget as HTMLElement | null;
     const response = await MetadataService.persistValue(KEY, contacts);
     if (response.ok) {
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
 
@@ -146,6 +151,37 @@
       }
     );
   };
+
+  const onContactChange = () => {
+    hasUnsavedLocalChange = true;
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          pointsOfContact: contacts
+        }
+      };
+    }
+  };
+
+  $effect(() => {
+    if (!hasUnsavedLocalChange || !formState.metadata?.isoMetadata) {
+      return;
+    }
+    const serverValue = JSON.stringify(formState.metadata.isoMetadata.pointsOfContact || []);
+    const localValue = JSON.stringify(contacts || []);
+    if (serverValue === localValue) {
+      return;
+    }
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        pointsOfContact: contacts
+      }
+    };
+  });
 
   let hasInvalidFields = $derived.by(() => {
     if (!fieldConfig) return false;
@@ -198,6 +234,7 @@
           <TextInput
             bind:value={contact.name}
             label={t('19_ContactsField.name')}
+            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={nameConfig}
             validationResult={nameConfig?.validator(contact.name)}
@@ -215,6 +252,7 @@
           <TextInput
             bind:value={contact.organisation}
             label={t('19_ContactsField.organisation')}
+            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={organisationConfig}
             validationResult={organisationConfig?.validator(contact.organisation)}
@@ -232,6 +270,7 @@
           <TextInput
             bind:value={contact.phone}
             label={t('19_ContactsField.phone')}
+            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={phoneConfig}
             validationResult={phoneConfig?.validator(contact.phone)}
@@ -249,6 +288,7 @@
           <TextInput
             bind:value={contact.email}
             label={t('19_ContactsField.email')}
+            onchange={onContactChange}
             onblur={persistContacts}
             fieldConfig={emailConfig}
             validationResult={emailConfig?.validator(contact.email)}

--- a/src/lib/components/Form/Field/25_TermsOfUseField.svelte
+++ b/src/lib/components/Form/Field/25_TermsOfUseField.svelte
@@ -99,6 +99,7 @@
   });
 
   const onChange = async (newValue: string) => {
+    if (fieldConfig?.validator(Number(newValue)).valid === false) return;
     const response = await MetadataService.persistValue(KEY, Number(newValue));
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
+++ b/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
@@ -27,6 +27,7 @@
   );
 
   const onBlur = async () => {
+    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
+++ b/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
@@ -10,17 +10,22 @@
   const TERMS_OF_USE_KEY = 'isoMetadata.termsOfUseId';
   const PRIVACY_KEY = 'isoMetadata.privacy';
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string>(KEY));
   const termsOfUseId = $derived(getValue<number>(TERMS_OF_USE_KEY));
   const privacy = $derived(getValue<string>(PRIVACY_KEY));
 
   let value = $derived(valueFromData ?? '');
 
+  $effect(() => {
+    if (!formState.metadata?.isoMetadata) return;
+    formState.metadata.isoMetadata.termsOfUseSource = value;
+  });
+
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(26);
   let validationResult = $derived(
-    fieldConfig.validator(value, {
+    fieldConfig?.validator(value, {
       'isoMetadata.termsOfUseId': termsOfUseId,
       'isoMetadata.privacy': privacy
     })

--- a/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
+++ b/src/lib/components/Form/Field/26_TermsOfUseSourceField.svelte
@@ -19,7 +19,18 @@
 
   $effect(() => {
     if (!formState.metadata?.isoMetadata) return;
-    formState.metadata.isoMetadata.termsOfUseSource = value;
+
+    if (formState.metadata.isoMetadata.termsOfUseSource === value) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        termsOfUseSource: value
+      }
+    };
   });
 
   let showCheckmark = $state(false);

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -75,6 +75,11 @@
     if (!Number.isNaN(min) && Number(target.value) < min) {
       return;
     }
+    const selectedValidationResult =
+      selected === RESOLUTION_KEY ? resolutionValidationResult : scaleValidationResult;
+    if (selectedValidationResult?.valid === false) {
+      return;
+    }
     if (selected === RESOLUTION_KEY) {
       await updateResolution(resolutionValue ? [resolutionValue] : null);
     } else {

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -61,14 +61,31 @@
     !resolutionValidationResult?.valid && !scaleValidationResult?.valid
   );
 
+  const syncLocalResolutionState = () => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        resolutions: resolutionValue ? [resolutionValue] : null,
+        scale: scaleValue
+      }
+    };
+  };
+
   const clearAllValues = async () => {
     scaleValue = null;
     resolutionValue = null;
+    syncLocalResolutionState();
     await updateResolution(null);
     await updateScale(null);
   };
 
   const onBlur = async (event: FocusEvent) => {
+    syncLocalResolutionState();
     const target = event.target as HTMLInputElement;
     const minValue = target.getAttribute('min');
     const min = Number(minValue);

--- a/src/lib/components/Form/Field/28_ResolutionField.svelte
+++ b/src/lib/components/Form/Field/28_ResolutionField.svelte
@@ -8,6 +8,7 @@
   import FieldTools from '../FieldTools.svelte';
   import NumberInput from '../Inputs/NumberInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { MetadataUpdateService } from '$lib/services/MetadataUpdateService';
   import FormField from '@smui/form-field';
   import Radio from '@smui/radio';
 
@@ -24,24 +25,37 @@
   let selected = $state<typeof RESOLUTION_KEY | typeof SCALE_KEY>();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formState.metadata);
+  let hasUnsavedLocalChange = $state(false);
 
   // TODO: check why this is a List
   const resolutionValueFromData = $derived(getValue<number[]>(RESOLUTION_KEY)?.[0]);
   let resolutionValue = $state<number | null>(null);
-  $effect(() => {
-    if (resolutionValueFromData) {
-      resolutionValue = resolutionValueFromData;
-      selected = RESOLUTION_KEY;
-    }
-  });
-
   const scaleValueFromData = $derived(getValue<number>(SCALE_KEY));
   let scaleValue = $state<number | null>(null);
   $effect(() => {
-    if (scaleValueFromData) {
-      scaleValue = scaleValueFromData;
-      selected = SCALE_KEY;
+    if (hasUnsavedLocalChange) {
+      return;
     }
+    const hasResolution = resolutionValueFromData !== undefined && resolutionValueFromData !== null;
+    const hasScale = scaleValueFromData !== undefined && scaleValueFromData !== null;
+
+    if (hasResolution) {
+      resolutionValue = resolutionValueFromData;
+      scaleValue = hasScale ? scaleValueFromData : null;
+      selected = RESOLUTION_KEY;
+      return;
+    }
+
+    if (hasScale) {
+      scaleValue = scaleValueFromData;
+      resolutionValue = null;
+      selected = SCALE_KEY;
+      return;
+    }
+
+    resolutionValue = null;
+    scaleValue = null;
+    selected = undefined;
   });
 
   let showCheckmark = $state(false);
@@ -61,36 +75,50 @@
     !resolutionValidationResult?.valid && !scaleValidationResult?.valid
   );
 
-  const syncLocalResolutionState = () => {
-    if (!formState.metadata?.isoMetadata) {
-      return;
-    }
-
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        resolutions: resolutionValue ? [resolutionValue] : null,
-        scale: scaleValue
-      }
-    };
-  };
-
   const clearAllValues = async () => {
-    scaleValue = null;
-    resolutionValue = null;
-    syncLocalResolutionState();
-    await updateResolution(null);
-    await updateScale(null);
+    hasUnsavedLocalChange = true;
+    if (selected === RESOLUTION_KEY) {
+      resolutionValue = null;
+      if (formState.metadata?.isoMetadata) {
+        formState.metadata = {
+          ...formState.metadata,
+          isoMetadata: {
+            ...formState.metadata.isoMetadata,
+            resolutions: null
+          }
+        };
+      }
+    } else if (selected === SCALE_KEY) {
+      scaleValue = null;
+      if (formState.metadata?.isoMetadata) {
+        formState.metadata = {
+          ...formState.metadata,
+          isoMetadata: {
+            ...formState.metadata.isoMetadata,
+            scale: null
+          }
+        };
+      }
+    }
   };
 
   const onBlur = async (event: FocusEvent) => {
-    syncLocalResolutionState();
+    hasUnsavedLocalChange = true;
     const target = event.target as HTMLInputElement;
     const minValue = target.getAttribute('min');
     const min = Number(minValue);
     if (!Number.isNaN(min) && Number(target.value) < min) {
       return;
+    }
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          resolutions: selected === RESOLUTION_KEY && resolutionValue ? [resolutionValue] : null,
+          scale: selected === SCALE_KEY ? scaleValue : null
+        }
+      };
     }
     const selectedValidationResult =
       selected === RESOLUTION_KEY ? resolutionValidationResult : scaleValidationResult;
@@ -98,24 +126,40 @@
       return;
     }
     if (selected === RESOLUTION_KEY) {
-      await updateResolution(resolutionValue ? [resolutionValue] : null);
+      await updateScale(null);
+      const saved = await updateResolution(resolutionValue ? [resolutionValue] : null);
+      if (saved) {
+        hasUnsavedLocalChange = false;
+      }
     } else {
-      await updateScale(scaleValue);
+      await updateResolution(null);
+      const saved = await updateScale(scaleValue);
+      if (saved) {
+        hasUnsavedLocalChange = false;
+      }
     }
   };
 
   const updateResolution = async (newValue: [number] | null) => {
-    const response = await MetadataService.persistValue(RESOLUTION_KEY, newValue);
+    const response =
+      newValue === null
+        ? await MetadataUpdateService.pushToQueue(RESOLUTION_KEY, null)
+        : await MetadataService.persistValue(RESOLUTION_KEY, newValue);
     if (response.ok) {
       showCheckmark = true;
     }
+    return response.ok;
   };
 
   const updateScale = async (newValue: number | null) => {
-    const response = await MetadataService.persistValue(SCALE_KEY, newValue);
+    const response =
+      newValue === null
+        ? await MetadataUpdateService.pushToQueue(SCALE_KEY, null)
+        : await MetadataService.persistValue(SCALE_KEY, newValue);
     if (response.ok) {
       showCheckmark = true;
     }
+    return response.ok;
   };
 </script>
 

--- a/src/lib/components/Form/Field/29_PreviewField.svelte
+++ b/src/lib/components/Form/Field/29_PreviewField.svelte
@@ -17,7 +17,14 @@
   const { getValue } = getFormContext();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
-  let value = $derived(valueFromData ?? '');
+  let value = $state('');
+  let hasUnsavedLocalChange = $state(false);
+  $effect(() => {
+    if (hasUnsavedLocalChange) {
+      return;
+    }
+    value = valueFromData || '';
+  });
 
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(29);
@@ -45,6 +52,7 @@
     if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
   };
@@ -53,6 +61,9 @@
 <div class="preview-field">
   <TextInput
     bind:value
+    onchange={() => {
+      hasUnsavedLocalChange = true;
+    }}
     label={t('29_PreviewField.label')}
     explanation={t('29_PreviewField.explanation')}
     {fieldConfig}

--- a/src/lib/components/Form/Field/29_PreviewField.svelte
+++ b/src/lib/components/Form/Field/29_PreviewField.svelte
@@ -18,6 +18,7 @@
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
 
   const onBlur = async () => {
+    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/29_PreviewField.svelte
+++ b/src/lib/components/Form/Field/29_PreviewField.svelte
@@ -1,21 +1,45 @@
 <script lang="ts">
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
-  import { getFormContext } from '$lib/context/FormContext.svelte';
+  import {
+    FORMSTATE_CONTEXT,
+    getFormContext,
+    type FormState
+  } from '$lib/context/FormContext.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
   import type { ValidationResult } from '../FieldsConfig';
   import { page } from '$app/state';
+  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
   const KEY = 'isoMetadata.preview';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<string>(KEY));
   let value = $derived(valueFromData ?? '');
 
   let showCheckmark = $state(false);
   const fieldConfig = MetadataService.getFieldConfig<string>(29);
   let validationResult = $derived(fieldConfig?.validator(value)) as ValidationResult;
+
+  $effect(() => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    if (formState.metadata.isoMetadata.preview === value) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        preview: value
+      }
+    };
+  });
 
   const onBlur = async () => {
     if (validationResult?.valid === false) return;

--- a/src/lib/components/Form/Field/30_ContentDescription.svelte
+++ b/src/lib/components/Form/Field/30_ContentDescription.svelte
@@ -21,6 +21,7 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onBlur = async () => {
+    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/31_TechnicalDescription.svelte
+++ b/src/lib/components/Form/Field/31_TechnicalDescription.svelte
@@ -21,6 +21,7 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onBlur = async () => {
+    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -2,6 +2,7 @@
   import type { Lineage, MetadataCollection } from '$lib/models/metadata';
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '../Inputs/TextInput.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
   import FieldTools from '../FieldTools.svelte';
@@ -12,6 +13,7 @@
   import { getPopconfirm } from '$lib/context/PopConfirmContext.svelte';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
+  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -21,6 +23,7 @@
   const KEY = 'isoMetadata.lineage';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<Lineage[]>(KEY));
   let lineages = $state<Lineage[]>([]);
 
@@ -96,6 +99,8 @@
   };
 
   const persistLineages = async (evt?: FocusEvent) => {
+    syncLocalLineageState();
+
     if (hasInvalidFields) {
       return;
     }
@@ -118,6 +123,29 @@
       elementToFocus?.focus();
     }, 10);
   };
+
+  const syncLocalLineageState = () => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    const currentLineage = formState.metadata.isoMetadata.lineage || [];
+    if (JSON.stringify(currentLineage) === JSON.stringify(lineages)) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        lineage: lineages
+      }
+    };
+  };
+
+  $effect(() => {
+    syncLocalLineageState();
+  });
 
   const addItem = (evt: MouseEvent) => {
     evt.preventDefault();

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -96,6 +96,9 @@
   };
 
   const persistLineages = async (evt?: FocusEvent) => {
+    if (hasInvalidFields) {
+      return;
+    }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;

--- a/src/lib/components/Form/Field/38_InspireAnnexVersionField.svelte
+++ b/src/lib/components/Form/Field/38_InspireAnnexVersionField.svelte
@@ -37,6 +37,7 @@
   );
 
   const onBlur = async () => {
+    if (validationResult?.valid === false) return;
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
+++ b/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
@@ -23,6 +23,7 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onChange = async (newValue?: string[]) => {
+    if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
+++ b/src/lib/components/Form/Field/39_SpatialRepresentationField.svelte
@@ -14,7 +14,7 @@
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
-  const { getValue } = getFormContext();
+  const { getValue, formState } = getFormContext();
   const valueFromData = $derived(getValue<string[]>(KEY));
   let value = $derived<string[] | undefined>(valueFromData);
 
@@ -23,6 +23,15 @@
   let validationResult = $derived(fieldConfig?.validator(value));
 
   const onChange = async (newValue?: string[]) => {
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          spatialRepresentationTypes: newValue
+        }
+      };
+    }
     if (fieldConfig?.validator(newValue).valid === false) return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {

--- a/src/lib/components/Form/Field/41_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/41_AdditionalInformation.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import IconButton from '@smui/icon-button';
   import { getFormContext } from '$lib/context/FormContext.svelte';
+  import { FORMSTATE_CONTEXT, type FormState } from '$lib/context/FormContext.svelte';
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
   import { MetadataService } from '$lib/services/MetadataService';
@@ -11,6 +12,7 @@
   import { page } from '$app/state';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
+  import { getContext } from 'svelte';
 
   const t = $derived(page.data.t);
 
@@ -20,6 +22,7 @@
   const KEY = 'isoMetadata.contentDescriptions';
 
   const { getValue } = getFormContext();
+  const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<ContentDescription[]>(KEY));
   let contentDescriptions = $state<ContentDescription[]>([]);
 
@@ -57,6 +60,8 @@
   const urlFieldConfig = MetadataService.getFieldConfig<string>(44);
 
   const persistContentDescriptions = async (evt?: FocusEvent) => {
+    syncLocalContentDescriptionsState();
+
     if (hasInvalidFields) {
       return;
     }
@@ -74,6 +79,29 @@
       elementToFocus?.focus();
     }, 10);
   };
+
+  const syncLocalContentDescriptionsState = () => {
+    if (!formState.metadata?.isoMetadata) {
+      return;
+    }
+
+    const currentContentDescriptions = formState.metadata.isoMetadata.contentDescriptions || [];
+    if (JSON.stringify(currentContentDescriptions) === JSON.stringify(contentDescriptions)) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        contentDescriptions
+      }
+    };
+  };
+
+  $effect(() => {
+    syncLocalContentDescriptionsState();
+  });
 
   const addItem = (evt: MouseEvent) => {
     evt.preventDefault();

--- a/src/lib/components/Form/Field/41_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/41_AdditionalInformation.svelte
@@ -57,6 +57,9 @@
   const urlFieldConfig = MetadataService.getFieldConfig<string>(44);
 
   const persistContentDescriptions = async (evt?: FocusEvent) => {
+    if (hasInvalidFields) {
+      return;
+    }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;

--- a/src/lib/components/Form/Field/70_InspireFormatName.svelte
+++ b/src/lib/components/Form/Field/70_InspireFormatName.svelte
@@ -48,6 +48,8 @@
   let options: Option[] = $state([]);
 
   const onChange = async (newValue?: string) => {
+    if (ValidationService.validateField(fieldConfig, newValue, { metadata }).valid === false)
+      return;
     const response = await MetadataService.persistValue(KEY, newValue);
     if (response.ok) {
       showCheckmark = true;

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -741,7 +741,7 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     profileId: 45,
     key: 'isoMetadata.services.workspace',
     collectionKey: 'isoMetadata.services',
-    extraParams: ['PARENT_VALUE', 'HIGHEST_ROLE'],
+    extraParams: ['PARENT_VALUE', 'HIGHEST_ROLE', 'isoMetadata.services'],
     validator: (workspace: Service['workspace'], extraParams) => {
       const highestRole = extraParams?.['HIGHEST_ROLE'] as string;
       const required = ['MdeEditor', 'MdeAdministrator'].includes(highestRole);
@@ -754,6 +754,17 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
           valid: false,
           helpText:
             'Bitte geben Sie einen gültigen Workspace an. Nur Buchstaben, Zahlen und Unterstriche sind erlaubt.'
+        };
+      }
+      const service = extraParams?.['PARENT_VALUE'] as Service;
+      const services = (extraParams?.['isoMetadata.services'] || []) as Service[];
+      const hasDuplicateWorkspace = services.some(
+        (entry) => entry.id !== service?.id && entry.workspace === workspace
+      );
+      if (hasDuplicateWorkspace) {
+        return {
+          valid: false,
+          helpText: 'Der angegebene Identifikator ist bereits vergeben.'
         };
       }
       return { valid };

--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -759,7 +759,10 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       const service = extraParams?.['PARENT_VALUE'] as Service;
       const services = (extraParams?.['isoMetadata.services'] || []) as Service[];
       const hasDuplicateWorkspace = services.some(
-        (entry) => entry.id !== service?.id && entry.workspace === workspace
+        (entry) =>
+          entry.id !== service?.id &&
+          entry.workspace === workspace &&
+          entry.serviceType === service?.serviceType
       );
       if (hasDuplicateWorkspace) {
         return {

--- a/src/lib/components/Form/Inputs/DateInput.svelte
+++ b/src/lib/components/Form/Inputs/DateInput.svelte
@@ -68,6 +68,10 @@
     id={key}
     name={key}
     bind:value
+    oninput={(evt) => {
+      value = (evt.currentTarget as HTMLInputElement).value;
+      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLInputElement });
+    }}
     onblur={(evt) => {
       value = (evt.currentTarget as HTMLInputElement).value;
       onblur?.(evt);

--- a/src/lib/components/Form/Inputs/TextAreaInput.svelte
+++ b/src/lib/components/Form/Inputs/TextAreaInput.svelte
@@ -51,6 +51,9 @@
   <textarea
     {maxlength}
     bind:value
+    oninput={(evt) => {
+      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLTextAreaElement });
+    }}
     onfocus={(evt) => {
       fieldHasFocus = true;
       onfocus?.(evt);

--- a/src/lib/components/Form/Inputs/TextInput.svelte
+++ b/src/lib/components/Form/Inputs/TextInput.svelte
@@ -54,6 +54,9 @@
   <input
     type="text"
     autocomplete="off"
+    oninput={(evt) => {
+      restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLInputElement });
+    }}
     onfocus={(evt) => {
       fieldHasFocus = true;
       onfocus?.(evt);

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -20,12 +20,14 @@
   import { toast } from 'svelte-french-toast';
   import { invalidateAll } from '$app/navigation';
   import { logger } from 'loggisch';
+  import { getAccessToken } from '$lib/context/TokenContext.svelte';
+  import { getHighestRole } from '$lib/util';
 
   const t = $derived(page.data.t);
 
   export type ServiceFormProps = {
     service: Service;
-    onChange: (service: Service) => Promise<Response>;
+    onChange: (service: Service, persist?: boolean) => Promise<Response>;
   };
 
   let { service, onChange }: ServiceFormProps = $props();
@@ -33,6 +35,8 @@
   const { getValue } = getFormContext();
   const formContext = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formContext.metadata);
+  const token = $derived(getAccessToken());
+  const highestRole = $derived(getHighestRole(token));
 
   const layers = $derived.by((): Layer[] => {
     const layersMap: Record<string, Layer[]> = metadata?.clientMetadata?.layers;
@@ -67,13 +71,12 @@
       // Remove feature types associated with the service
       delete service.featureTypes;
     }
-    return onChange(service);
+    return onChange(service, true);
   }
 
-  async function set(key: string, value: Service[keyof Service]) {
+  async function set<K extends keyof Service>(key: K, value: Service[K]) {
     service = setNestedValue(service, key, value);
-
-    const response = await onChange(service);
+    const response = await onChange(service, shouldPersistFieldValue(key, value));
     if (response.ok) {
       if (key === 'serviceType') {
         onServiceTypeChange(value as ServiceType);
@@ -93,6 +96,42 @@
     }
     return response;
   }
+
+  const shouldPersistFieldValue = <K extends keyof Service>(key: K, value: Service[K]) => {
+    if (key === 'workspace') {
+      const fieldConfig = MetadataService.getFieldConfig<string>(45);
+      return fieldConfig?.validator(value as Service['workspace'], {
+        ['PARENT_VALUE']: service,
+        ['HIGHEST_ROLE']: highestRole
+      }).valid;
+    }
+    if (key === 'preview') {
+      const fieldConfig = MetadataService.getFieldConfig<string>(46);
+      return fieldConfig?.validator(value as Service['preview'], {
+        ['PARENT_VALUE']: service
+      }).valid;
+    }
+    if (key === 'title') {
+      const fieldConfig = MetadataService.getFieldConfig<string>(59);
+      return fieldConfig?.validator(value as Service['title']).valid;
+    }
+    if (key === 'shortDescription') {
+      const fieldConfig = MetadataService.getFieldConfig<string>(60);
+      return fieldConfig?.validator(value as Service['shortDescription']).valid;
+    }
+    if (key === 'featureTypes') {
+      const fieldConfig = MetadataService.getFieldConfig<Service['featureTypes']>(56);
+      return fieldConfig?.validator(value as Service['featureTypes'], {
+        ['PARENT_VALUE']: service
+      }).valid;
+    }
+    if (key === 'serviceType') {
+      const fieldConfig = MetadataService.getFieldConfig<ServiceType>(58);
+      return fieldConfig?.validator(value as Service['serviceType']).valid;
+    }
+
+    return true;
+  };
 
   async function onLayersChange(layers: Layer[]) {
     const serviceIdentification = service?.serviceIdentification;

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -77,6 +77,11 @@
   }
 
   async function set<K extends keyof Service>(key: K, value: Service[K], persist?: boolean) {
+    const serviceIdentification = service?.serviceIdentification;
+    const localLayersBeforePersist = serviceIdentification
+      ? formContext.metadata?.clientMetadata?.layers?.[serviceIdentification]
+      : undefined;
+
     service = setNestedValue(service, key, value);
     const shouldPersist = persist ?? shouldPersistFieldValue(key, value);
     const response = await onChange(service, shouldPersist);
@@ -96,6 +101,25 @@
         }
       }
       await invalidateAll();
+      // keep local layer edits (including invalid, not persisted values) when only service fields change
+      if (
+        key !== 'serviceType' &&
+        serviceIdentification &&
+        (service.serviceType === 'WMS' || service.serviceType === 'WMTS') &&
+        localLayersBeforePersist &&
+        formContext.metadata
+      ) {
+        formContext.metadata = {
+          ...formContext.metadata,
+          clientMetadata: {
+            ...formContext.metadata.clientMetadata,
+            layers: {
+              ...(formContext.metadata.clientMetadata?.layers || {}),
+              [serviceIdentification]: localLayersBeforePersist
+            }
+          }
+        };
+      }
     }
     return response;
   }

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -22,6 +22,8 @@
   import { logger } from 'loggisch';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
+  import { validateFeatureTypes } from './validation';
+  import { ValidationService } from '$lib/services/ValidationService';
 
   const t = $derived(page.data.t);
 
@@ -74,9 +76,10 @@
     return onChange(service, true);
   }
 
-  async function set<K extends keyof Service>(key: K, value: Service[K]) {
+  async function set<K extends keyof Service>(key: K, value: Service[K], persist?: boolean) {
     service = setNestedValue(service, key, value);
-    const response = await onChange(service, shouldPersistFieldValue(key, value));
+    const shouldPersist = persist ?? shouldPersistFieldValue(key, value);
+    const response = await onChange(service, shouldPersist);
     if (response.ok) {
       if (key === 'serviceType') {
         onServiceTypeChange(value as ServiceType);
@@ -100,9 +103,10 @@
   const shouldPersistFieldValue = <K extends keyof Service>(key: K, value: Service[K]) => {
     if (key === 'workspace') {
       const fieldConfig = MetadataService.getFieldConfig<string>(45);
-      return fieldConfig?.validator(value as Service['workspace'], {
+      return ValidationService.validateField(fieldConfig, value as Service['workspace'], {
         ['PARENT_VALUE']: service,
-        ['HIGHEST_ROLE']: highestRole
+        ['HIGHEST_ROLE']: highestRole,
+        metadata
       }).valid;
     }
     if (key === 'preview') {
@@ -121,9 +125,16 @@
     }
     if (key === 'featureTypes') {
       const fieldConfig = MetadataService.getFieldConfig<Service['featureTypes']>(56);
-      return fieldConfig?.validator(value as Service['featureTypes'], {
+      const featureTypes = value as Service['featureTypes'];
+      const hasValidFeatureTypeCollection = fieldConfig?.validator(featureTypes, {
         ['PARENT_VALUE']: service
       }).valid;
+      const hasInvalidFeatureTypes =
+        validateFeatureTypes(featureTypes || [], {
+          metadata,
+          HIGHEST_ROLE: highestRole
+        }).size > 0;
+      return hasValidFeatureTypeCollection && !hasInvalidFeatureTypes;
     }
     if (key === 'serviceType') {
       const fieldConfig = MetadataService.getFieldConfig<ServiceType>(58);
@@ -133,9 +144,26 @@
     return true;
   };
 
-  async function onLayersChange(layers: Layer[]) {
+  async function onLayersChange(layers: Layer[], persist = true) {
     const serviceIdentification = service?.serviceIdentification;
     if (!serviceIdentification) return Promise.reject('Service identification is missing');
+
+    if (formContext.metadata) {
+      formContext.metadata = {
+        ...formContext.metadata,
+        clientMetadata: {
+          ...formContext.metadata.clientMetadata,
+          layers: {
+            ...(formContext.metadata.clientMetadata?.layers || {}),
+            [serviceIdentification]: layers
+          }
+        }
+      };
+    }
+
+    if (!persist) {
+      return new Response(null, { status: 422, statusText: 'Validation failed' });
+    }
 
     const response = await fetch(
       `${page.url.origin}${page.url.pathname}/updateLayers/${serviceIdentification}`,
@@ -152,23 +180,27 @@
 
     if (!response.ok) {
       toast.error(t('serviceform.layer_update_error', { statusText: response.statusText }));
+    } else {
+      await invalidateAll();
     }
-    invalidateAll();
     return response;
   }
 </script>
 
 <div class="service-form">
   <ServiceType_58 value={service.serviceType} onChange={onServiceTypeChange} />
-  <ServiceTitle_59 value={service.title} onChange={(title) => set('title', title)} />
+  <ServiceTitle_59
+    value={service.title}
+    onChange={(title, persist) => set('title', title, persist)}
+  />
   <ServiceShortDescription_60
     value={service.shortDescription}
-    onChange={(shortDescription) => set('shortDescription', shortDescription)}
+    onChange={(shortDescription, persist) => set('shortDescription', shortDescription, persist)}
   />
   <ServiceWorkspace_45
     value={service.workspace}
     {service}
-    onChange={(workspace) => set('workspace', workspace)}
+    onChange={(workspace, persist) => set('workspace', workspace, persist)}
   />
   <ServicePreview_46
     value={service.preview}
@@ -186,7 +218,7 @@
     <FeatureTypeForm_56
       {service}
       value={service.featureTypes}
-      onChange={(featureTypes) => set('featureTypes', featureTypes)}
+      onChange={(featureTypes, persist) => set('featureTypes', featureTypes, persist)}
     />
   {/if}
 </div>

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -146,7 +146,7 @@
     );
   }
 
-  async function updateService(id: string, newService: Service) {
+  async function updateService(id: string, newService: Service, persist = true) {
     if (!id || !newService) {
       return Promise.reject('Invalid parameters');
     }
@@ -156,6 +156,21 @@
       }
       return service;
     });
+
+    if (formState.metadata?.isoMetadata) {
+      formState.metadata = {
+        ...formState.metadata,
+        isoMetadata: {
+          ...formState.metadata.isoMetadata,
+          services
+        }
+      };
+    }
+
+    if (!persist) {
+      return new Response(null, { status: 422, statusText: 'Validation failed' });
+    }
+
     return persistServices(id);
   }
 
@@ -227,8 +242,8 @@
     <span>
       <ServiceForm_40
         service={activeService}
-        onChange={(newService) => {
-          return updateService(activeService?.id, newService);
+        onChange={(newService, persist) => {
+          return updateService(activeService?.id, newService, persist);
         }}
       />
     </span>

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -93,7 +93,10 @@
     if (validation.valid === false) return false;
 
     return !serviceList.some(
-      (entry) => entry.id !== service.id && entry.workspace === service.workspace
+      (entry) =>
+        entry.id !== service.id &&
+        entry.workspace === service.workspace &&
+        entry.serviceType === service.serviceType
     );
   };
 

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -12,6 +12,7 @@
   import { validateService } from './validation';
   import { MetadataService } from '$lib/services/MetadataService';
   import { SvelteSet } from 'svelte/reactivity';
+  import { ValidationService } from '$lib/services/ValidationService';
 
   const t = $derived(page.data.t);
 
@@ -31,7 +32,8 @@
   const highestRole = $derived(getHighestRole(token));
 
   let initialServices = getValue<Service[]>(KEY);
-  let services = $derived<Service[]>(initialServices || []);
+  let services = $state<Service[]>([]);
+  let lastPersistedServices = $state<Service[]>(initialServices || []);
   let tabs = $derived<Tab[]>(
     services.map((service) => {
       const mappingService = service.serviceType === 'WMS' || service.serviceType === 'WMTS';
@@ -75,14 +77,42 @@
 
   $effect(() => {
     services = initialServices || [];
+    lastPersistedServices = initialServices || [];
     activeTab = initialServices?.length ? initialServices[0].id : '';
   });
 
   let visibleCheckmarks = $state<Record<string, boolean>>({});
 
+  const isWorkspacePersistable = (service: Service, serviceList: Service[]) => {
+    const fieldConfig = MetadataService.getFieldConfig<string>(45);
+    const validation = ValidationService.validateField(fieldConfig, service.workspace, {
+      metadata,
+      PARENT_VALUE: service,
+      HIGHEST_ROLE: highestRole
+    });
+    if (validation.valid === false) return false;
+
+    return !serviceList.some(
+      (entry) => entry.id !== service.id && entry.workspace === service.workspace
+    );
+  };
+
+  const getPersistableServices = (serviceList: Service[]) => {
+    return serviceList.map((service) => {
+      if (isWorkspacePersistable(service, serviceList)) {
+        return service;
+      }
+
+      const lastPersisted = lastPersistedServices.find((entry) => entry.id === service.id);
+      return lastPersisted ? { ...service, workspace: lastPersisted.workspace } : service;
+    });
+  };
+
   const persistServices = async (id: string) => {
-    const response = await MetadataService.persistValue(KEY, services);
+    const persistableServices = getPersistableServices(services);
+    const response = await MetadataService.persistValue(KEY, persistableServices);
     if (response.ok) {
+      lastPersistedServices = persistableServices;
       visibleCheckmarks[id] = true;
     }
     return response;
@@ -243,7 +273,7 @@
       <ServiceForm_40
         service={activeService}
         onChange={(newService, persist) => {
-          return updateService(activeService?.id, newService, persist);
+          return updateService(newService?.id, newService, persist);
         }}
       />
     </span>

--- a/src/lib/components/Form/service/48_LayersForm.svelte
+++ b/src/lib/components/Form/service/48_LayersForm.svelte
@@ -28,7 +28,7 @@
   export type LayersFormProps = {
     value?: Layer[];
     service?: Service;
-    onChange: (layers: Layer[]) => Promise<Response>;
+    onChange: (layers: Layer[], persist?: boolean) => Promise<Response>;
   };
 
   let { value: initialLayers, service, onChange }: LayersFormProps = $props();
@@ -80,6 +80,7 @@
         styleName: ''
       }
     ];
+    syncLocalLayers(layers);
     activeTabId = id;
     onChange(layers);
   }
@@ -91,6 +92,7 @@
       targetEl,
       async () => {
         layers = layers.filter((layer) => layer.id !== layerId);
+        syncLocalLayers(layers);
         if (activeTabId === layerId) {
           activeTabId = layers.length > 0 ? layers[layers.length - 1]?.id : undefined;
         }
@@ -107,7 +109,7 @@
     );
   }
 
-  function set(key: string, value: Layer[keyof Layer]) {
+  function set(key: string, value: Layer[keyof Layer], persist?: boolean) {
     layers = layers.map((layer) => {
       if (layer.id === activeTabId) {
         return {
@@ -117,7 +119,25 @@
       }
       return layer;
     });
-    return onChange(layers);
+    syncLocalLayers(layers);
+    return onChange(layers, persist);
+  }
+
+  function syncLocalLayers(nextLayers: Layer[]) {
+    if (!formState.metadata || !serviceId) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      clientMetadata: {
+        ...formState.metadata.clientMetadata,
+        layers: {
+          ...(formState.metadata.clientMetadata?.layers || {}),
+          [serviceId]: nextLayers
+        }
+      }
+    };
   }
 </script>
 
@@ -172,15 +192,21 @@
     </nav>
     <div class="content">
       {#if activeTabId && activeLayer}
-        <LayerTitle_49 value={activeLayer?.title} onChange={(title) => set('title', title)} />
-        <LayerName_50 value={activeLayer?.name} onChange={(name) => set('name', name)} />
+        <LayerTitle_49
+          value={activeLayer?.title}
+          onChange={(title, persist) => set('title', title, persist)}
+        />
+        <LayerName_50
+          value={activeLayer?.name}
+          onChange={(name, persist) => set('name', name, persist)}
+        />
         <LayerStyleTitle_52
           value={activeLayer?.styleTitle}
-          onChange={(styleTitle) => set('styleTitle', styleTitle)}
+          onChange={(styleTitle, persist) => set('styleTitle', styleTitle, persist)}
         />
         <LayerStyleName_51
           value={activeLayer?.styleName}
-          onChange={(styleName) => set('styleName', styleName)}
+          onChange={(styleName, persist) => set('styleName', styleName, persist)}
         />
         <LayerLegendImage_53
           value={activeLayer?.legendImage}
@@ -188,7 +214,8 @@
         />
         <LayerDescription_54
           value={activeLayer?.shortDescription}
-          onChange={(shortDescription) => set('shortDescription', shortDescription)}
+          onChange={(shortDescription, persist) =>
+            set('shortDescription', shortDescription, persist)}
         />
         <LayerDatasource_55
           value={activeLayer?.datasource}

--- a/src/lib/components/Form/service/56_FeatureTypeForm.svelte
+++ b/src/lib/components/Form/service/56_FeatureTypeForm.svelte
@@ -77,6 +77,7 @@
         columns: []
       }
     ];
+    syncLocalFeatureTypes(featureTypes);
     activeTabId = id;
     onChange(featureTypes);
   }
@@ -88,6 +89,7 @@
       targetEl,
       async () => {
         featureTypes = featureTypes.filter((featureType) => featureType.id !== id);
+        syncLocalFeatureTypes(featureTypes);
         if (activeTabId === id) {
           activeTabId = featureTypes.length > 1 ? featureTypes[0].id : undefined;
         }
@@ -114,7 +116,60 @@
       }
       return featureType;
     });
+    syncLocalFeatureTypes(featureTypes);
     return onChange(featureTypes);
+  }
+
+  function syncLocalFeatureTypes(nextFeatureTypes: FeatureType[]) {
+    if (!formState.metadata?.isoMetadata?.services) {
+      return;
+    }
+
+    let hasMatchedService = false;
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        services: formState.metadata.isoMetadata.services.map((entry: Service) => {
+          const isTargetService =
+            entry.id === service.id ||
+            entry.serviceIdentification === service.serviceIdentification;
+
+          if (!isTargetService) {
+            return entry;
+          }
+
+          hasMatchedService = true;
+          return {
+            ...entry,
+            featureTypes: nextFeatureTypes
+          };
+        })
+      }
+    };
+
+    if (hasMatchedService) {
+      return;
+    }
+
+    formState.metadata = {
+      ...formState.metadata,
+      isoMetadata: {
+        ...formState.metadata.isoMetadata,
+        services: formState.metadata.isoMetadata.services.map((entry: Service) => {
+          const hasFeatureTypeFromCurrentService = entry.featureTypes?.some((ft: FeatureType) =>
+            nextFeatureTypes.some((nextFt) => nextFt.id === ft.id)
+          );
+          if (!hasFeatureTypeFromCurrentService) {
+            return entry;
+          }
+          return {
+            ...entry,
+            featureTypes: nextFeatureTypes
+          };
+        })
+      }
+    };
   }
 </script>
 

--- a/src/lib/components/Form/service/56_FeatureTypeForm.svelte
+++ b/src/lib/components/Form/service/56_FeatureTypeForm.svelte
@@ -24,7 +24,7 @@
   export type FeatureTypeFormProps = {
     value?: FeatureType[];
     service: Service;
-    onChange: (featureTypes: FeatureType[]) => Promise<Response>;
+    onChange: (featureTypes: FeatureType[], persist?: boolean) => Promise<Response>;
   };
 
   let { value: initialFeatureTypes, onChange, service }: FeatureTypeFormProps = $props();
@@ -106,7 +106,7 @@
     );
   }
 
-  function set(key: string, value: FeatureType[keyof FeatureType]) {
+  function set(key: string, value: FeatureType[keyof FeatureType], persist?: boolean) {
     featureTypes = featureTypes.map((featureType) => {
       if (featureType.id === activeTabId) {
         return {
@@ -117,7 +117,7 @@
       return featureType;
     });
     syncLocalFeatureTypes(featureTypes);
-    return onChange(featureTypes);
+    return onChange(featureTypes, persist);
   }
 
   function syncLocalFeatureTypes(nextFeatureTypes: FeatureType[]) {
@@ -228,21 +228,22 @@
       {#if activeTabId && activeFeatureType}
         <FeatureTypeTitle_61
           value={activeFeatureType?.title}
-          onChange={(title) => set('title', title)}
+          onChange={(title, persist) => set('title', title, persist)}
         />
         <FeatureTypeName_62
           featureType={activeFeatureType}
           value={activeFeatureType?.name}
-          onChange={(name) => set('name', name)}
+          onChange={(name, persist) => set('name', name, persist)}
         />
         <FeatureTypeDescription_69
           value={activeFeatureType?.shortDescription}
-          onChange={(shortDescription) => set('shortDescription', shortDescription)}
+          onChange={(shortDescription, persist) =>
+            set('shortDescription', shortDescription, persist)}
         />
         <ColumnsForm_63
           featureType={activeFeatureType}
           value={activeFeatureType?.columns}
-          onChange={(columns) => set('columns', columns)}
+          onChange={(columns, persist) => set('columns', columns, persist)}
         />
       {/if}
     </div>

--- a/src/lib/components/Form/service/63_ColumnsForm.svelte
+++ b/src/lib/components/Form/service/63_ColumnsForm.svelte
@@ -23,7 +23,7 @@
   export type ColumnsFormProps = {
     featureType: FeatureType;
     value?: ColumnInfo[];
-    onChange: (columns: ColumnInfo[]) => Promise<Response>;
+    onChange: (columns: ColumnInfo[], persist?: boolean) => Promise<Response>;
   };
 
   let { value: initialColumns, onChange, featureType }: ColumnsFormProps = $props();
@@ -97,7 +97,7 @@
     );
   }
 
-  function set(key: string, value: ColumnInfo[keyof ColumnInfo]) {
+  function set(key: string, value: ColumnInfo[keyof ColumnInfo], persist?: boolean) {
     columns = columns.map((column) => {
       if (column.id === activeTabId) {
         return {
@@ -107,7 +107,7 @@
       }
       return column;
     });
-    return onChange(columns);
+    return onChange(columns, persist);
   }
 </script>
 
@@ -162,9 +162,18 @@
     </nav>
     <div class="content">
       {#if activeTabId && activeColumn}
-        <AttributeName_64 value={activeColumn?.name} onChange={(name) => set('name', name)} />
-        <AttributeAlias_65 value={activeColumn?.alias} onChange={(alias) => set('alias', alias)} />
-        <AttributeDatatype_66 value={activeColumn?.type} onChange={(type) => set('type', type)} />
+        <AttributeName_64
+          value={activeColumn?.name}
+          onChange={(name, persist) => set('name', name, persist)}
+        />
+        <AttributeAlias_65
+          value={activeColumn?.alias}
+          onChange={(alias, persist) => set('alias', alias, persist)}
+        />
+        <AttributeDatatype_66
+          value={activeColumn?.type}
+          onChange={(type, persist) => set('type', type, persist)}
+        />
       {/if}
     </div>
   </fieldset>

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -53,13 +53,6 @@
         hasDuplicatedValue = false;
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
-        const newValidationResult = fieldConfig?.validator(newValue, {
-          ['PARENT_VALUE']: service,
-          ['HIGHEST_ROLE']: highestRole
-        });
-        if (newValidationResult?.valid === false) {
-          return;
-        }
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -15,6 +15,10 @@
   };
 
   let { value, service, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
@@ -29,7 +33,7 @@
         helpText: 'Der angegebene Identifikator ist bereits vergeben.'
       };
     }
-    return fieldConfig?.validator(value, {
+    return fieldConfig?.validator(localValue, {
       ['PARENT_VALUE']: service,
       ['HIGHEST_ROLE']: highestRole
     });
@@ -42,12 +46,21 @@
   <div class="service-id-field">
     <TextInput
       label={t('45_ServiceWorkspace.label')}
-      {value}
+      value={localValue}
       {fieldConfig}
       {validationResult}
       onchange={async (e: Event) => {
         hasDuplicatedValue = false;
-        const response = await onChange((e.target as HTMLInputElement).value);
+        const newValue = (e.target as HTMLInputElement).value;
+        localValue = newValue;
+        const newValidationResult = fieldConfig?.validator(newValue, {
+          ['PARENT_VALUE']: service,
+          ['HIGHEST_ROLE']: highestRole
+        });
+        if (newValidationResult?.valid === false) {
+          return;
+        }
+        const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;
         } else if (response.status === 409) {

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -2,6 +2,7 @@
   import TextInput from '$lib/components/Form/Inputs/TextInput.svelte';
   import type { Service } from '$lib/models/metadata';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { getFormContext } from '$lib/context/FormContext.svelte';
   import { getHighestRole } from '$lib/util';
   import FieldTools from '$lib/components/Form/FieldTools.svelte';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
@@ -11,7 +12,7 @@
   export type ComponentProps = {
     value?: Service['workspace'];
     service: Service;
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, service, onChange }: ComponentProps = $props();
@@ -22,10 +23,22 @@
 
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
+  const { getValue } = getFormContext();
 
   const HELP_KEY = 'isoMetadata.services.workspace';
   const fieldConfig = MetadataService.getFieldConfig(45);
   let hasDuplicatedValue = $state<boolean>(false);
+  const isDuplicateServiceId = (nextValue: string) => {
+    const allServices = getValue<Service[]>('isoMetadata.services') || [];
+    return allServices.some((entry) => entry.id !== service.id && entry.workspace === nextValue);
+  };
+  const isInvalidWorkspace = (nextValue: string) => {
+    const nextValidation = fieldConfig?.validator(nextValue, {
+      ['PARENT_VALUE']: service,
+      ['HIGHEST_ROLE']: highestRole
+    });
+    return hasDuplicatedValue || nextValidation?.valid === false;
+  };
   const validationResult = $derived.by(() => {
     if (hasDuplicatedValue) {
       return {
@@ -38,6 +51,9 @@
       ['HIGHEST_ROLE']: highestRole
     });
   });
+  $effect(() => {
+    hasDuplicatedValue = isDuplicateServiceId(localValue);
+  });
   let showCheckmark = $state(false);
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
 </script>
@@ -49,15 +65,23 @@
       value={localValue}
       {fieldConfig}
       {validationResult}
-      onchange={async (e: Event) => {
-        hasDuplicatedValue = false;
+      onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+        hasDuplicatedValue = isDuplicateServiceId(newValue);
+        void onChange(newValue, false);
+      }}
+      onblur={async (e: Event) => {
+        const newValue = (e.target as HTMLInputElement).value;
+        hasDuplicatedValue = isDuplicateServiceId(newValue);
+        if (isInvalidWorkspace(newValue)) return;
+
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;
         } else if (response.status === 409) {
           hasDuplicatedValue = true;
+          void onChange(value || '', false);
         }
       }}
     />

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -30,7 +30,12 @@
   let hasDuplicatedValue = $state<boolean>(false);
   const isDuplicateServiceId = (nextValue: string) => {
     const allServices = getValue<Service[]>('isoMetadata.services') || [];
-    return allServices.some((entry) => entry.id !== service.id && entry.workspace === nextValue);
+    return allServices.some(
+      (entry) =>
+        entry.id !== service.id &&
+        entry.workspace === nextValue &&
+        entry.serviceType === service.serviceType
+    );
   };
   const isInvalidWorkspace = (nextValue: string) => {
     const nextValidation = fieldConfig?.validator(nextValue, {

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -16,10 +16,7 @@
   };
 
   let { value, service, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
@@ -27,7 +24,6 @@
 
   const HELP_KEY = 'isoMetadata.services.workspace';
   const fieldConfig = MetadataService.getFieldConfig(45);
-  let hasDuplicatedValue = $state<boolean>(false);
   const isDuplicateServiceId = (nextValue: string) => {
     const allServices = getValue<Service[]>('isoMetadata.services') || [];
     return allServices.some(
@@ -37,6 +33,7 @@
         entry.serviceType === service.serviceType
     );
   };
+  let hasDuplicatedValue = $derived(isDuplicateServiceId(localValue));
   const isInvalidWorkspace = (nextValue: string) => {
     const nextValidation = fieldConfig?.validator(nextValue, {
       ['PARENT_VALUE']: service,
@@ -55,9 +52,6 @@
       ['PARENT_VALUE']: service,
       ['HIGHEST_ROLE']: highestRole
     });
-  });
-  $effect(() => {
-    hasDuplicatedValue = isDuplicateServiceId(localValue);
   });
   let showCheckmark = $state(false);
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -17,10 +17,14 @@
   };
 
   let { value, service, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const fieldConfig = MetadataService.getFieldConfig(46);
   const validationResult = $derived(
-    fieldConfig?.validator(value, {
+    fieldConfig?.validator(localValue, {
       ['PARENT_VALUE']: service
     })
   );
@@ -36,6 +40,10 @@
 
   const getAutoFillValues = async () => {
     if (!metadataPreview) return;
+    const nextValidation = fieldConfig?.validator(metadataPreview, {
+      ['PARENT_VALUE']: service
+    });
+    if (nextValidation?.valid === false) return;
     const response = await onChange(metadataPreview);
     if (response.ok) {
       showCheckmark = true;
@@ -47,11 +55,17 @@
   <TextInput
     label={t('46_ServicePreview.label')}
     explanation={t('46_ServicePreview.explanation')}
-    {value}
+    value={localValue}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      const nextValidation = fieldConfig?.validator(newValue, {
+        ['PARENT_VALUE']: service
+      });
+      if (nextValidation?.valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -61,10 +61,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      const nextValidation = fieldConfig?.validator(newValue, {
-        ['PARENT_VALUE']: service
-      });
-      if (nextValidation?.valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -13,7 +13,7 @@
   export type ComponentProps = {
     value?: Service['preview'];
     service: Service;
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, service, onChange }: ComponentProps = $props();
@@ -58,9 +58,13 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -17,10 +17,7 @@
   };
 
   let { value, service, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const fieldConfig = MetadataService.getFieldConfig(46);
   const validationResult = $derived(

--- a/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
@@ -17,22 +17,39 @@
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
+  let localValue = $state(value);
+  $effect(() => {
+    localValue = value;
+  });
 
   const fieldConfig = MetadataService.getFieldConfig(47);
   const fieldConfigUrl = MetadataService.getFieldConfig(75);
   const fieldConfigFormat = MetadataService.getFieldConfig(76);
   const fieldConfigWidth = MetadataService.getFieldConfig(77);
   const fieldConfigHeight = MetadataService.getFieldConfig(78);
-  const validationResult = $derived(fieldConfig?.validator(value));
-  const validationResultUrl = $derived(fieldConfigUrl?.validator(value?.url));
-  const validationResultFormat = $derived(fieldConfigFormat?.validator(value?.format));
-  const validationResultWidth = $derived(fieldConfigWidth?.validator(value?.width));
-  const validationResultHeight = $derived(fieldConfigHeight?.validator(value?.height));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
+  const validationResultUrl = $derived(fieldConfigUrl?.validator(localValue?.url));
+  const validationResultFormat = $derived(fieldConfigFormat?.validator(localValue?.format));
+  const validationResultWidth = $derived(fieldConfigWidth?.validator(localValue?.width));
+  const validationResultHeight = $derived(fieldConfigHeight?.validator(localValue?.height));
   let showCheckmark = $state(false);
 
   const update = async (key: string, val: string | number) => {
+    localValue = {
+      ...localValue,
+      [key]: val
+    };
+    const fieldValidationMap: Record<string, { valid?: boolean } | undefined> = {
+      url: fieldConfigUrl?.validator(key === 'url' ? val : localValue?.url),
+      format: fieldConfigFormat?.validator(key === 'format' ? val : localValue?.format),
+      width: fieldConfigWidth?.validator(key === 'width' ? val : localValue?.width),
+      height: fieldConfigHeight?.validator(key === 'height' ? val : localValue?.height)
+    };
+    if (fieldValidationMap[key]?.valid === false) {
+      return;
+    }
     const response = await onChange({
-      ...value,
+      ...localValue,
       [key]: val
     });
     if (response.ok) {

--- a/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/47_ServiceLegendImage.svelte
@@ -17,10 +17,7 @@
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
-  let localValue = $state(value);
-  $effect(() => {
-    localValue = value;
-  });
+  let localValue = $derived(value);
 
   const fieldConfig = MetadataService.getFieldConfig(47);
   const fieldConfigUrl = MetadataService.getFieldConfig(75);

--- a/src/lib/components/Form/service/Field/49_LayerTitle.svelte
+++ b/src/lib/components/Form/service/Field/49_LayerTitle.svelte
@@ -12,10 +12,14 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'clientMetadata.layers.title';
   const fieldConfig = MetadataService.getFieldConfig(49);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
   let showCheckmark = $state(false);
 </script>
 
@@ -23,12 +27,15 @@
   <TextInput
     label={t('49_LayerTitle.label')}
     explanation={t('49_LayerTitle.explanation')}
-    {value}
+    value={localValue}
     {fieldConfig}
     {validationResult}
     maxlength={250}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/49_LayerTitle.svelte
+++ b/src/lib/components/Form/service/Field/49_LayerTitle.svelte
@@ -12,10 +12,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'clientMetadata.layers.title';
   const fieldConfig = MetadataService.getFieldConfig(49);

--- a/src/lib/components/Form/service/Field/49_LayerTitle.svelte
+++ b/src/lib/components/Form/service/Field/49_LayerTitle.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: Layer['title'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -31,9 +31,13 @@
     {fieldConfig}
     {validationResult}
     maxlength={250}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/50_LayerName.svelte
+++ b/src/lib/components/Form/service/Field/50_LayerName.svelte
@@ -14,6 +14,10 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'clientMetadata.layers.name';
 
@@ -21,7 +25,7 @@
   const highestRole = $derived(getHighestRole(token));
   const fieldConfig = MetadataService.getFieldConfig(50);
   const validationResult = $derived(
-    fieldConfig?.validator(value, {
+    fieldConfig?.validator(localValue, {
       ['HIGHEST_ROLE']: highestRole
     })
   );
@@ -30,6 +34,14 @@
 
   const onChangeInternal = async (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
+    localValue = newValue;
+    if (
+      fieldConfig?.validator(newValue, {
+        ['HIGHEST_ROLE']: highestRole
+      }).valid === false
+    ) {
+      return;
+    }
     const response = await onChange(newValue);
     if (response.ok) {
       showCheckmark = true;
@@ -41,7 +53,7 @@
   <div class="layer-name-field">
     <TextInput
       label={t('50_LayerName.label')}
-      {value}
+      value={localValue}
       maxlength={100}
       {fieldConfig}
       {validationResult}

--- a/src/lib/components/Form/service/Field/50_LayerName.svelte
+++ b/src/lib/components/Form/service/Field/50_LayerName.svelte
@@ -10,7 +10,7 @@
 
   export type ComponentProps = {
     value?: Layer['name'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -32,9 +32,14 @@
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
   let showCheckmark = $state(false);
 
-  const onChangeInternal = async (e: Event) => {
+  const onChangeInternal = (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
     localValue = newValue;
+    void onChange(newValue, false);
+  };
+
+  const onBlurInternal = async (e: Event) => {
+    const newValue = (e.target as HTMLInputElement).value;
     if (
       fieldConfig?.validator(newValue, {
         ['HIGHEST_ROLE']: highestRole
@@ -58,6 +63,7 @@
       {fieldConfig}
       {validationResult}
       onchange={onChangeInternal}
+      onblur={onBlurInternal}
     />
     <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>

--- a/src/lib/components/Form/service/Field/50_LayerName.svelte
+++ b/src/lib/components/Form/service/Field/50_LayerName.svelte
@@ -14,10 +14,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'clientMetadata.layers.name';
 

--- a/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
+++ b/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
@@ -14,6 +14,10 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'clientMetadata.layers.styleName';
   let showCheckmark = $state(false);
@@ -23,7 +27,7 @@
 
   const fieldConfig = MetadataService.getFieldConfig(51);
   const validationResult = $derived(
-    fieldConfig?.validator(value, {
+    fieldConfig?.validator(localValue, {
       ['HIGHEST_ROLE']: highestRole
     })
   );
@@ -31,6 +35,14 @@
 
   const onChangeInternal = async (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
+    localValue = newValue;
+    if (
+      fieldConfig?.validator(newValue, {
+        ['HIGHEST_ROLE']: highestRole
+      }).valid === false
+    ) {
+      return;
+    }
     const response = await onChange(newValue);
     if (response.ok) {
       showCheckmark = true;
@@ -42,7 +54,7 @@
   <div class="layer-style-name-field">
     <TextInput
       label={t('51_LayerStyleName.label')}
-      {value}
+      value={localValue}
       maxlength={100}
       {fieldConfig}
       {validationResult}

--- a/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
+++ b/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
@@ -14,10 +14,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'clientMetadata.layers.styleName';
   let showCheckmark = $state(false);

--- a/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
+++ b/src/lib/components/Form/service/Field/51_LayerStyleName.svelte
@@ -10,7 +10,7 @@
 
   export type ComponentProps = {
     value?: Layer['styleName'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -33,9 +33,14 @@
   );
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
 
-  const onChangeInternal = async (e: Event) => {
+  const onChangeInternal = (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value;
     localValue = newValue;
+    void onChange(newValue, false);
+  };
+
+  const onBlurInternal = async (e: Event) => {
+    const newValue = (e.target as HTMLInputElement).value;
     if (
       fieldConfig?.validator(newValue, {
         ['HIGHEST_ROLE']: highestRole
@@ -59,6 +64,7 @@
       {fieldConfig}
       {validationResult}
       onchange={onChangeInternal}
+      onblur={onBlurInternal}
     />
     <FieldTools {value} key={HELP_KEY} bind:checkMarkAnmiationRunning={showCheckmark} />
   </div>

--- a/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
+++ b/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
@@ -18,6 +18,10 @@
   const HELP_KEY = 'clientMetadata.layers.styleTitle';
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
   let showCheckmark = $state(false);
 
   const { getValue } = getFormContext();
@@ -27,7 +31,7 @@
   const highestRole = $derived(getHighestRole(token));
   const fieldConfig = MetadataService.getFieldConfig(52);
   const validationResult = $derived(
-    fieldConfig?.validator(value, {
+    fieldConfig?.validator(localValue, {
       HIGHEST_ROLE: highestRole,
       'isoMetadata.metadataProfile': metadataProfile
     })
@@ -43,12 +47,22 @@
   <div class="layer-style-title-field">
     <TextInput
       label={t('52_LayerStyleTitle.label')}
-      {value}
+      value={localValue}
       maxlength={250}
       {fieldConfig}
       {validationResult}
       onchange={async (e: Event) => {
-        const response = await onChange((e.target as HTMLInputElement).value);
+        const newValue = (e.target as HTMLInputElement).value;
+        localValue = newValue;
+        if (
+          fieldConfig?.validator(newValue, {
+            HIGHEST_ROLE: highestRole,
+            'isoMetadata.metadataProfile': metadataProfile
+          }).valid === false
+        ) {
+          return;
+        }
+        const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
+++ b/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
@@ -18,10 +18,7 @@
   const HELP_KEY = 'clientMetadata.layers.styleTitle';
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
   let showCheckmark = $state(false);
 
   const { getValue } = getFormContext();

--- a/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
+++ b/src/lib/components/Form/service/Field/52_LayerStyleTitle.svelte
@@ -11,7 +11,7 @@
 
   export type ComponentProps = {
     value?: Layer['styleTitle'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   const PROFILE_KEY = 'isoMetadata.metadataProfile';
@@ -51,9 +51,13 @@
       maxlength={250}
       {fieldConfig}
       {validationResult}
-      onchange={async (e: Event) => {
+      onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+        void onChange(newValue, false);
+      }}
+      onblur={async (e: Event) => {
+        const newValue = (e.target as HTMLInputElement).value;
         if (
           fieldConfig?.validator(newValue, {
             HIGHEST_ROLE: highestRole,

--- a/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
@@ -12,23 +12,30 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'clientMetadata.layers.legendImage';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(53);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
 </script>
 
 <div class="layer-legend-image-field">
   <TextInput
     label={t('53_LayerLegendImage.label')}
     explanation={t('53_LayerLegendImage.explanation')}
-    {value}
+    value={localValue}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
@@ -31,9 +31,12 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
+++ b/src/lib/components/Form/service/Field/53_LayerLegendImage.svelte
@@ -12,10 +12,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'clientMetadata.layers.legendImage';
   let showCheckmark = $state(false);

--- a/src/lib/components/Form/service/Field/54_LayerDescription.svelte
+++ b/src/lib/components/Form/service/Field/54_LayerDescription.svelte
@@ -12,24 +12,31 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'clientMetadata.layers.shortDescription';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(54);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
 </script>
 
 <div class="layer-short-description-field">
   <TextAreaInput
     label={t('54_LayerDescription.label')}
     explanation={t('54_LayerDescription.explanation')}
-    {value}
+    value={localValue}
     maxlength={500}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/54_LayerDescription.svelte
+++ b/src/lib/components/Form/service/Field/54_LayerDescription.svelte
@@ -12,10 +12,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'clientMetadata.layers.shortDescription';
   let showCheckmark = $state(false);

--- a/src/lib/components/Form/service/Field/54_LayerDescription.svelte
+++ b/src/lib/components/Form/service/Field/54_LayerDescription.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: Layer['shortDescription'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -32,9 +32,13 @@
     maxlength={500}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
+++ b/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
@@ -12,10 +12,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'clientMetadata.layers.datasource';
   let showCheckmark = $state(false);

--- a/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
+++ b/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
@@ -31,9 +31,12 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
+++ b/src/lib/components/Form/service/Field/55_LayerDatasource.svelte
@@ -12,23 +12,30 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'clientMetadata.layers.datasource';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(55);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
 </script>
 
 <div class="layer-datasource-field">
   <TextInput
     label={t('55_LayerDatasource.label')}
     explanation={t('55_LayerDatasource.explanation')}
-    {value}
+    value={localValue}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/58_ServiceType.svelte
+++ b/src/lib/components/Form/service/Field/58_ServiceType.svelte
@@ -12,9 +12,13 @@
     onChange: (newValue: ServiceType) => Promise<Response>;
   };
   let { value, onChange }: ServiceTypeProps = $props();
+  let localValue = $state(value);
+  $effect(() => {
+    localValue = value;
+  });
 
   const fieldConfig = MetadataService.getFieldConfig(58);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
   let showCheckmark = $state(false);
   const HELP_KEY = 'isoMetadata.services.type';
 </script>
@@ -23,7 +27,7 @@
   <SelectInput
     label={t('58_ServiceType.label')}
     explanation={t('58_ServiceType.explanation')}
-    {value}
+    value={localValue}
     {fieldConfig}
     {validationResult}
     options={[
@@ -45,7 +49,10 @@
       }
     ]}
     onChange={async (value) => {
-      const response = await onChange(value as ServiceType);
+      const newValue = value as ServiceType;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/58_ServiceType.svelte
+++ b/src/lib/components/Form/service/Field/58_ServiceType.svelte
@@ -12,10 +12,7 @@
     onChange: (newValue: ServiceType) => Promise<Response>;
   };
   let { value, onChange }: ServiceTypeProps = $props();
-  let localValue = $state(value);
-  $effect(() => {
-    localValue = value;
-  });
+  let localValue = $derived(value);
 
   const fieldConfig = MetadataService.getFieldConfig(58);
   const validationResult = $derived(fieldConfig?.validator(localValue));

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -26,11 +26,17 @@
   const metadataTitle = $derived(getValue<string>(METADATA_TITLE_KEY, metadata));
 
   const fieldConfig = MetadataService.getFieldConfig(59);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
+  const validationResult = $derived(fieldConfig?.validator(localValue));
   let showCheckmark = $state(false);
 
   const getAutoFillValues = async () => {
     if (!metadataTitle) return;
+    if (fieldConfig?.validator(metadataTitle).valid === false) return;
+    localValue = metadataTitle;
     const response = await onChange(metadataTitle);
     if (response.ok) {
       showCheckmark = true;
@@ -42,12 +48,15 @@
   <TextInput
     label={t('59_ServiceTitle.label')}
     explanation={t('59_ServiceTitle.explanation')}
-    {value}
+    value={localValue}
     {fieldConfig}
     {validationResult}
     maxlength={250}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -55,7 +55,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -26,10 +26,7 @@
   const metadataTitle = $derived(getValue<string>(METADATA_TITLE_KEY, metadata));
 
   const fieldConfig = MetadataService.getFieldConfig(59);
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
   const validationResult = $derived(fieldConfig?.validator(localValue));
   let showCheckmark = $state(false);
 

--- a/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
+++ b/src/lib/components/Form/service/Field/59_ServiceTitle.svelte
@@ -12,7 +12,7 @@
 
   export type ServiceTypeProps = {
     value: Service['title'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -52,9 +52,13 @@
     {fieldConfig}
     {validationResult}
     maxlength={250}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -30,6 +30,7 @@
 
   const getAutoFillValues = async () => {
     if (!metadataDescription) return;
+    if (fieldConfig?.validator(metadataDescription).valid === false) return;
     const response = await onChange(metadataDescription);
     if (response.ok) {
       showCheckmark = true;
@@ -47,7 +48,9 @@
     {validationResult}
     rows={5}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -49,7 +49,6 @@
     rows={5}
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
+++ b/src/lib/components/Form/service/Field/60_ServiceShortDescription.svelte
@@ -12,7 +12,7 @@
 
   export type ServiceTypeProps = {
     value: Service['shortDescription'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value = $bindable(), onChange }: ServiceTypeProps = $props();
@@ -47,7 +47,12 @@
     {fieldConfig}
     {validationResult}
     rows={5}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
+      value = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -34,7 +34,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -12,10 +12,14 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.title';
   const fieldConfig = MetadataService.getFieldConfig(61);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
   let showCheckmark = $state(false);
 </script>
 
@@ -23,12 +27,15 @@
   <TextInput
     label={t('61_FeatureTypeTitle.label')}
     explanation={t('61_FeatureTypeTitle.explanation')}
-    {value}
+    value={localValue}
     maxlength={100}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: FeatureType['title'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -31,9 +31,13 @@
     maxlength={100}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
+++ b/src/lib/components/Form/service/Field/61_FeatureTypeTitle.svelte
@@ -12,10 +12,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.title';
   const fieldConfig = MetadataService.getFieldConfig(61);

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -18,6 +18,10 @@
   };
 
   let { value, featureType, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
@@ -26,7 +30,7 @@
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const metadata = $derived(formState.metadata);
   const validationResult = $derived(
-    ValidationService.validateField(fieldConfig, value, {
+    ValidationService.validateField(fieldConfig, localValue, {
       HIGHEST_ROLE: highestRole,
       PARENT_VALUE: featureType,
       metadata
@@ -40,12 +44,20 @@
   <div class="featuretype-name-field">
     <TextInput
       label={t('62_FeatureTypeName.label')}
-      {value}
+      value={localValue}
       maxlength={100}
       {fieldConfig}
       {validationResult}
       onchange={async (e: Event) => {
-        const response = await onChange((e.target as HTMLInputElement).value);
+        const newValue = (e.target as HTMLInputElement).value;
+        localValue = newValue;
+        const nextValidation = ValidationService.validateField(fieldConfig, newValue, {
+          HIGHEST_ROLE: highestRole,
+          PARENT_VALUE: featureType,
+          metadata
+        });
+        if (nextValidation.valid === false) return;
+        const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -51,12 +51,6 @@
       onchange={async (e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
-        const nextValidation = ValidationService.validateField(fieldConfig, newValue, {
-          HIGHEST_ROLE: highestRole,
-          PARENT_VALUE: featureType,
-          metadata
-        });
-        if (nextValidation.valid === false) return;
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -18,10 +18,7 @@
   };
 
   let { value, featureType, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 

--- a/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
+++ b/src/lib/components/Form/service/Field/62_FeatureTypeName.svelte
@@ -14,7 +14,7 @@
   export type ComponentProps = {
     value?: FeatureType['name'];
     featureType: FeatureType;
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, featureType, onChange }: ComponentProps = $props();
@@ -48,9 +48,13 @@
       maxlength={100}
       {fieldConfig}
       {validationResult}
-      onchange={async (e: Event) => {
+      onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+        void onChange(newValue, false);
+      }}
+      onblur={async (e: Event) => {
+        const newValue = (e.target as HTMLInputElement).value;
         const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -33,7 +33,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -12,10 +12,14 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.columns.name';
   const fieldConfig = MetadataService.getFieldConfig(64);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
   let showCheckmark = $state(false);
 </script>
 
@@ -23,11 +27,14 @@
   <TextInput
     label={t('64_AttributeName.label')}
     explanation={t('64_AttributeName.explanation')}
-    {value}
+    value={localValue}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: ColumnInfo['name'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -30,9 +30,13 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -12,10 +12,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.columns.name';
   const fieldConfig = MetadataService.getFieldConfig(64);

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -33,7 +33,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -12,10 +12,14 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.columns.alias';
   const fieldConfig = MetadataService.getFieldConfig(65);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
   let showCheckmark = $state(false);
 </script>
 
@@ -23,11 +27,14 @@
   <TextInput
     label={t('65_AttributeAlias.label')}
     explanation={t('65_AttributeAlias.explanation')}
-    {value}
+    value={localValue}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -12,10 +12,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.columns.alias';
   const fieldConfig = MetadataService.getFieldConfig(65);

--- a/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
+++ b/src/lib/components/Form/service/Field/65_AttributeAlias.svelte
@@ -8,7 +8,7 @@
 
   export type ComponentProps = {
     value?: ColumnInfo['alias'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -30,9 +30,13 @@
     value={localValue}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -11,7 +11,7 @@
 
   export type ServiceTypeProps = {
     value?: ColumnInfo['type'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: ColumnInfo['type']) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -55,8 +55,9 @@
       onChange={async (newValue) => {
         const typedValue = newValue as ColumnInfo['type'];
         localValue = typedValue;
-        if (!typedValue) return;
-        if (fieldConfig?.validator(typedValue).valid === false) return;
+        if (typedValue === undefined) {
+          return;
+        }
         const response = await onChange(typedValue);
         if (response.ok) {
           showCheckmark = true;

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -15,13 +15,17 @@
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
+  let localValue = $state(value);
+  $effect(() => {
+    localValue = value;
+  });
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.columns.type';
   const fieldConfig = MetadataService.getFieldConfig(66);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
   let showCheckmark = $state(false);
 
   const options: Option[] = [
@@ -46,10 +50,14 @@
       label={t('66_AttributeDatatype.label')}
       {fieldConfig}
       {validationResult}
-      {value}
+      value={localValue}
       {options}
       onChange={async (newValue) => {
-        const response = await onChange(newValue);
+        const typedValue = newValue as ColumnInfo['type'];
+        localValue = typedValue;
+        if (!typedValue) return;
+        if (fieldConfig?.validator(typedValue).valid === false) return;
+        const response = await onChange(typedValue);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -15,10 +15,7 @@
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
-  let localValue = $state(value);
-  $effect(() => {
-    localValue = value;
-  });
+  let localValue = $derived(value);
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
   const fieldVisible = $derived(['MdeEditor', 'MdeAdministrator'].includes(highestRole));

--- a/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
+++ b/src/lib/components/Form/service/Field/66_AttributeDatatype.svelte
@@ -11,7 +11,7 @@
 
   export type ServiceTypeProps = {
     value?: ColumnInfo['type'];
-    onChange: (newValue: ColumnInfo['type']) => Promise<Response>;
+    onChange: (newValue: ColumnInfo['type'], persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ServiceTypeProps = $props();
@@ -55,10 +55,7 @@
       onChange={async (newValue) => {
         const typedValue = newValue as ColumnInfo['type'];
         localValue = typedValue;
-        if (typedValue === undefined) {
-          return;
-        }
-        const response = await onChange(typedValue);
+        const response = await onChange(typedValue, typedValue !== undefined);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
+++ b/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
@@ -37,9 +37,12 @@
       value={localValue}
       {fieldConfig}
       {validationResult}
-      onchange={async (e: Event) => {
+      onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;
+      }}
+      onblur={async (e: Event) => {
+        const newValue = (e.target as HTMLInputElement).value;
         if (fieldConfig?.validator(newValue).valid === false) return;
         const response = await onChange(newValue);
         if (response.ok) {

--- a/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
+++ b/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
@@ -14,10 +14,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'clientMetadata.layers.secondaryDatasource';
   let showCheckmark = $state(false);

--- a/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
+++ b/src/lib/components/Form/service/Field/68_LayerSecondaryDatasource.svelte
@@ -14,12 +14,16 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'clientMetadata.layers.secondaryDatasource';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(68);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
 
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
@@ -30,11 +34,14 @@
   <div class="layer-secondary-datasource-field">
     <TextInput
       label={t('68_LayerSecondaryDatasource.label')}
-      {value}
+      value={localValue}
       {fieldConfig}
       {validationResult}
       onchange={async (e: Event) => {
-        const response = await onChange((e.target as HTMLInputElement).value);
+        const newValue = (e.target as HTMLInputElement).value;
+        localValue = newValue;
+        if (fieldConfig?.validator(newValue).valid === false) return;
+        const response = await onChange(newValue);
         if (response.ok) {
           showCheckmark = true;
         }

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -13,24 +13,31 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
+  let localValue = $state(value || '');
+  $effect(() => {
+    localValue = value || '';
+  });
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.shortDescription';
   let showCheckmark = $state(false);
 
   const fieldConfig = MetadataService.getFieldConfig(69);
-  const validationResult = $derived(fieldConfig?.validator(value));
+  const validationResult = $derived(fieldConfig?.validator(localValue));
 </script>
 
 <div class="featuretype-short-description-field">
   <TextAreaInput
     label={t('69_FeatureTypeDescription.label')}
     explanation={t('69_FeatureTypeDescription.explanation')}
-    {value}
+    value={localValue}
     maxlength={500}
     {fieldConfig}
     {validationResult}
     onchange={async (e: Event) => {
-      const response = await onChange((e.target as HTMLInputElement).value);
+      const newValue = (e.target as HTMLInputElement).value;
+      localValue = newValue;
+      if (fieldConfig?.validator(newValue).valid === false) return;
+      const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -36,7 +36,6 @@
     onchange={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      if (fieldConfig?.validator(newValue).valid === false) return;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -13,10 +13,7 @@
   };
 
   let { value, onChange }: ComponentProps = $props();
-  let localValue = $state(value || '');
-  $effect(() => {
-    localValue = value || '';
-  });
+  let localValue = $derived(value || '');
 
   const HELP_KEY = 'isoMetadata.services.featureTypes.shortDescription';
   let showCheckmark = $state(false);

--- a/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
+++ b/src/lib/components/Form/service/Field/69_FeatureTypeDescription.svelte
@@ -9,7 +9,7 @@
 
   export type ComponentProps = {
     value?: FeatureType['shortDescription'];
-    onChange: (newValue: string) => Promise<Response>;
+    onChange: (newValue: string, persist?: boolean) => Promise<Response>;
   };
 
   let { value, onChange }: ComponentProps = $props();
@@ -33,9 +33,13 @@
     maxlength={500}
     {fieldConfig}
     {validationResult}
-    onchange={async (e: Event) => {
+    onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
+      void onChange(newValue, false);
+    }}
+    onblur={async (e: Event) => {
+      const newValue = (e.target as HTMLInputElement).value;
       const response = await onChange(newValue);
       if (response.ok) {
         showCheckmark = true;

--- a/src/lib/components/Form/service/validation.ts
+++ b/src/lib/components/Form/service/validation.ts
@@ -192,7 +192,12 @@ export function validateService(
   const allServices = (context?.metadata?.isoMetadata?.services || []) as Service[];
   const hasDuplicateWorkspace =
     !!service?.workspace &&
-    allServices.some((entry) => entry.id !== service.id && entry.workspace === service.workspace);
+    allServices.some(
+      (entry) =>
+        entry.id !== service.id &&
+        entry.workspace === service.workspace &&
+        entry.serviceType === service.serviceType
+    );
   const featureTypesRequired = service.serviceType === 'WFS';
   const layersRequired = ['WMS', 'WMTS'].includes(service?.serviceType || '');
   let hasInvalidLayersFlag = false;

--- a/src/lib/components/Form/service/validation.ts
+++ b/src/lib/components/Form/service/validation.ts
@@ -189,6 +189,10 @@ export function validateService(
   ];
 
   const fieldsValid = validateFields(validations);
+  const allServices = (context?.metadata?.isoMetadata?.services || []) as Service[];
+  const hasDuplicateWorkspace =
+    !!service?.workspace &&
+    allServices.some((entry) => entry.id !== service.id && entry.workspace === service.workspace);
   const featureTypesRequired = service.serviceType === 'WFS';
   const layersRequired = ['WMS', 'WMTS'].includes(service?.serviceType || '');
   let hasInvalidLayersFlag = false;
@@ -202,7 +206,7 @@ export function validateService(
   }
 
   return {
-    hasInvalidFields: !fieldsValid,
+    hasInvalidFields: !fieldsValid || hasDuplicateWorkspace,
     hasInvalidLayers: hasInvalidLayersFlag,
     hasInvalidFeatureTypes: hasInvalidFeatureTypesFlag
   };

--- a/src/lib/services/MetadataService.ts
+++ b/src/lib/services/MetadataService.ts
@@ -102,12 +102,25 @@ export class MetadataService {
   /**
    * Persists a metadata value to the server.
    * Handles server communication, data invalidation, error handling, and user notifications.
+   * For required fields with empty values, returns a local 422 response instead of
+   * sending a request to the backend.
    *
    * @param key - Path to the value to persist (e.g., 'isoMetadata.title')
    * @param value - The value to persist
-   * @returns The server response
+   * @returns The server response, or a local 422 validation response
    */
   static async persistValue(key: string, value: unknown) {
+    const fieldConfig = FieldConfigs.find((config) => config.key === key);
+    const isEmptyValue =
+      value === null ||
+      value === undefined ||
+      value === '' ||
+      (Array.isArray(value) && value.length === 0);
+
+    if (fieldConfig?.required && isEmptyValue) {
+      return new Response(null, { status: 422, statusText: 'Validation failed' });
+    }
+
     return MetadataUpdateService.pushToQueue(key, value);
   }
 

--- a/src/lib/services/ValidationService.ts
+++ b/src/lib/services/ValidationService.ts
@@ -293,7 +293,10 @@ export class ValidationService {
         const parentConfig = FieldConfigs.find(({ key }) => key === field.collectionKey);
         if (!parentConfig) return;
 
-        const parentCollection = MetadataService.getAllValues(parentConfig.key, metadata!) as any[];
+        const parentCollection =
+          field.collectionKey === 'clientMetadata.layers'
+            ? (MetadataService.getValue<Service[]>('isoMetadata.services', metadata!) as any[])
+            : (MetadataService.getAllValues(parentConfig.key, metadata!) as any[]);
 
         // If parent collection is empty or not an array, skip validation
         if (!Array.isArray(parentCollection) || parentCollection.length === 0) {

--- a/src/lib/services/ValidationService.ts
+++ b/src/lib/services/ValidationService.ts
@@ -246,6 +246,9 @@ export class ValidationService {
                 // No service found for this layer, skip it
                 continue;
               }
+              if (layerService.id !== v.id) {
+                continue;
+              }
 
               const fieldPath = `clientMetadata.layers['${serviceId}']`;
               // handle the 'clientMetadata.layers' collection itself

--- a/tests/helpers/TestFieldHelpers.ts
+++ b/tests/helpers/TestFieldHelpers.ts
@@ -43,6 +43,7 @@ interface TestFieldOptions {
   // Validation
   requiredMessage?: string;
   expectInvalidClass?: boolean;
+  expectPersist?: boolean;
 
   // Help
   help?: boolean;
@@ -63,6 +64,7 @@ interface TestFieldOptions {
     fieldType: Exclude<FieldType, 'collection'>;
     fieldInput?: string | number;
     optionsCode?: string;
+    expectPersist?: boolean;
     fieldsetSelector: () => HTMLElement;
     help?: boolean;
     maxLength?: number;
@@ -137,7 +139,14 @@ async function waitForPatchCall(
 }
 
 async function testTextInput(fieldKey: string, options: TestFieldOptions): Promise<void> {
-  const { fieldset, fieldInput, requiredMessage, maxLength, expectInvalidClass } = options;
+  const {
+    fieldset,
+    fieldInput,
+    requiredMessage,
+    maxLength,
+    expectInvalidClass,
+    expectPersist = true
+  } = options;
 
   const input = await within(fieldset!).findByRole('textbox');
   expect(input).toBeInTheDocument();
@@ -171,6 +180,16 @@ async function testTextInput(fieldKey: string, options: TestFieldOptions): Promi
   await fireEvent.blur(input);
   await tick();
   await new Promise((r) => setTimeout(r, 0));
+
+  if (!expectPersist) {
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.slice(previousCallCount);
+      const patchCall = calls.find(([, init]) => init?.method === 'PATCH');
+      expect(patchCall).toBeUndefined();
+    });
+
+    return;
+  }
 
   const requestInit = await waitForPatchCall(previousCallCount, (body) => {
     return JSON.stringify(body).includes(fieldInput as string);
@@ -399,7 +418,7 @@ async function testNumberInput(fieldKey: string, options: TestFieldOptions): Pro
 }
 
 async function testDateInput(fieldKey: string, options: TestFieldOptions): Promise<void> {
-  const { fieldset, fieldInput } = options;
+  const { fieldset, fieldInput, expectPersist = true } = options;
 
   const input = await waitFor(() => {
     const el = fieldset!.querySelector('input[type="date"]');
@@ -418,6 +437,16 @@ async function testDateInput(fieldKey: string, options: TestFieldOptions): Promi
   await fireEvent.blur(input);
   await tick();
   await new Promise((r) => setTimeout(r, 0));
+
+  if (!expectPersist) {
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.slice(previousCallCount);
+      const patchCall = calls.find(([, init]) => init?.method === 'PATCH');
+      expect(patchCall).toBeUndefined();
+    });
+
+    return;
+  }
 
   const requestInit = await waitForPatchCall(previousCallCount, (body) => {
     return JSON.stringify(body).includes(fieldKey!);
@@ -494,7 +523,7 @@ async function testSelectInput(fieldKey: string, options: TestFieldOptions): Pro
 }
 
 async function testRadioInput(fieldKey: string, options: TestFieldOptions): Promise<void> {
-  const { fieldset, radioOptionKey } = options;
+  const { fieldset, radioOptionKey, expectPersist = true } = options;
 
   const previousCallCount = fetchMock.mock.calls.length;
 
@@ -508,20 +537,30 @@ async function testRadioInput(fieldKey: string, options: TestFieldOptions): Prom
   await tick();
   await new Promise((r) => setTimeout(r, 0));
 
-  const requestInit = await waitForPatchCall(previousCallCount, (body) => {
-    return JSON.stringify(body).includes(fieldKey!);
-  });
-  const body = JSON.parse(requestInit.body as string);
+  if (expectPersist) {
+    const requestInit = await waitForPatchCall(previousCallCount, (body) => {
+      return JSON.stringify(body).includes(fieldKey!);
+    });
+    const body = JSON.parse(requestInit.body as string);
 
-  expect(extractBaseKey(body.key)).toBe(fieldKey);
+    expect(extractBaseKey(body.key)).toBe(fieldKey);
+  } else {
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.slice(previousCallCount);
+      const patchCall = calls.find(([, init]) => init?.method === 'PATCH');
+      expect(patchCall).toBeUndefined();
+    });
+  }
 
   await waitFor(() => {
     expect(radioInput).toBeChecked();
   });
 
-  await waitFor(() => {
-    expect(document.querySelector('.running')).toBeVisible();
-  });
+  if (expectPersist) {
+    await waitFor(() => {
+      expect(document.querySelector('.running')).toBeVisible();
+    });
+  }
 }
 
 async function testSwitchInput(fieldKey: string, options: TestFieldOptions): Promise<void> {
@@ -668,26 +707,30 @@ async function testMultiSelectInput(fieldKey: string, options: TestFieldOptions)
       await tick();
       await new Promise((r) => setTimeout(r, 0));
 
-      const requestInit = await waitForPatchCall(previousCallCount, (body) => {
-        return JSON.stringify(body).includes(fieldKey!);
-      });
-      const body = JSON.parse(requestInit.body as string);
+      if (multiSelectOptions.length > 1) {
+        const requestInit = await waitForPatchCall(previousCallCount, (body) => {
+          return JSON.stringify(body).includes(fieldKey!);
+        });
+        const body = JSON.parse(requestInit.body as string);
 
-      expect(extractBaseKey(body.key)).toBe(fieldKey);
-      let value = body.value;
-      if (body.value.default) {
-        value = body.value.default;
+        expect(extractBaseKey(body.key)).toBe(fieldKey);
+        let value = body.value;
+        if (body.value.default) {
+          value = body.value.default;
+        }
+
+        if (typeof value === 'object') {
+          value = Object.values(value);
+        }
+
+        expect(value).not.toContain(firstChipText);
+      } else {
+        await waitFor(() => {
+          const calls = fetchMock.mock.calls.slice(previousCallCount);
+          const patchCall = calls.find(([, init]) => init?.method === 'PATCH');
+          expect(patchCall).toBeUndefined();
+        });
       }
-
-      if (typeof value === 'object') {
-        value = Object.values(value);
-      }
-
-      expect(value).not.toContain(firstChipText);
-
-      await waitForPatchCall(previousCallCount, (body) => {
-        return JSON.stringify(body).includes(fieldKey!);
-      });
 
       await waitFor(() => {
         expect(within(fieldset!).queryAllByText(firstChipText)).toHaveLength(1);
@@ -725,10 +768,9 @@ async function testCollectionInput(options: TestFieldOptions): Promise<void> {
   if (options.collectionFields) {
     const fields = options.collectionFields;
 
-    const initialCallCount = fetchMock.mock.calls.length;
-
     for (let i = 0; i < fields.length; i++) {
       const fieldConfig = fields[i];
+      const previousCallCount = fetchMock.mock.calls.length;
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(`/help/${fieldConfig.fieldKey}`);
@@ -782,26 +824,24 @@ async function testCollectionInput(options: TestFieldOptions): Promise<void> {
         throw new Error(`Unsupported field type in collection: ${fieldConfig.fieldType}`);
       }
 
-      await waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledWith(
-          expect.any(URL),
-          expect.objectContaining({
-            method: 'PATCH',
-            body: expect.stringContaining(
+      if (fieldConfig.expectPersist !== false) {
+        await waitFor(() => {
+          const calls = fetchMock.mock.calls.slice(previousCallCount);
+          const patchCall = calls.find(([, init]) => {
+            if (init?.method !== 'PATCH') return false;
+            return (init.body as string).includes(
               fieldConfig.fieldType === 'select'
                 ? String(fieldConfig.optionsCode)
                 : String(fieldConfig.fieldInput)
-            ),
-            headers: {
-              'content-type': 'application/json'
-            }
-          })
-        );
-      });
+            );
+          });
+          expect(patchCall).toBeDefined();
+        });
 
-      await waitFor(() => {
-        expect(document.querySelector('.running')).toBeVisible();
-      });
+        await waitFor(() => {
+          expect(document.querySelector('.running')).toBeVisible();
+        });
+      }
 
       await new Promise((r) => setTimeout(r, 50));
     }
@@ -809,7 +849,7 @@ async function testCollectionInput(options: TestFieldOptions): Promise<void> {
 }
 
 async function testServiceInput(fieldKey: string, options: TestFieldOptions): Promise<void> {
-  const { fieldset, fieldInput, requiredMessage } = options;
+  const { fieldset, fieldInput, requiredMessage, expectPersist = true } = options;
 
   const input = await within(fieldset!).findByRole('textbox');
 
@@ -836,6 +876,20 @@ async function testServiceInput(fieldKey: string, options: TestFieldOptions): Pr
   await fireEvent.blur(input);
   await tick();
   await new Promise((r) => setTimeout(r, 0));
+
+  if (!expectPersist) {
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.slice(previousCallCount);
+      const patchCall = calls.find(([, init]) => init?.method === 'PATCH');
+      expect(patchCall).toBeUndefined();
+    });
+
+    await waitFor(() => {
+      expect(input).toHaveValue(fieldInput as string);
+    });
+
+    return;
+  }
 
   await waitForPatchCall(previousCallCount, (body) => {
     return JSON.stringify(body).includes(fieldInput as string);

--- a/tests/integration/Additional.integration.ts
+++ b/tests/integration/Additional.integration.ts
@@ -79,10 +79,11 @@ export async function testAdditional(role: string) {
           expect(screen.queryAllByRole('group', { name: 'delete' }).length).toBeGreaterThan(0);
         });
 
-        const titleFieldset = (
-          document.querySelector('#isoMetadata\\.lineage-0-title') as HTMLInputElement
-        )?.closest('fieldset') as HTMLElement;
-
+        const titleInput = document.querySelector(
+          '#isoMetadata\\.lineage-0-title'
+        ) as HTMLInputElement | null;
+        expect(titleInput).toBeInTheDocument();
+        const titleFieldset = titleInput!.closest('fieldset') as HTMLElement;
         //TODO: Add test for search-input field like title
         await testField('isoMetadata.lineage[0].title', {
           fieldset: titleFieldset,
@@ -91,10 +92,11 @@ export async function testAdditional(role: string) {
           help: true
         });
 
-        const dateFieldset = (
-          document.querySelector('#isoMetadata\\.lineage-0-date') as HTMLInputElement
-        )?.closest('fieldset') as HTMLElement;
-
+        const dateInput = document.querySelector(
+          '#isoMetadata\\.lineage-0-date'
+        ) as HTMLInputElement | null;
+        expect(dateInput).toBeInTheDocument();
+        const dateFieldset = dateInput!.closest('fieldset') as HTMLElement;
         await testField('isoMetadata.lineage[0].date', {
           fieldset: dateFieldset,
           fieldType: 'date',
@@ -103,10 +105,11 @@ export async function testAdditional(role: string) {
           help: true
         });
 
-        const identifierFieldset = (
-          document.querySelector('#isoMetadata\\.lineage-0-identifier') as HTMLInputElement
-        )?.closest('fieldset') as HTMLElement;
-
+        const identifierInput = document.querySelector(
+          '#isoMetadata\\.lineage-0-identifier'
+        ) as HTMLInputElement | null;
+        expect(identifierInput).toBeInTheDocument();
+        const identifierFieldset = identifierInput!.closest('fieldset') as HTMLElement;
         await testField('isoMetadata.lineage[0].identifier', {
           fieldset: identifierFieldset,
           fieldInput: 'Test Identifier',

--- a/tests/integration/Additional.integration.ts
+++ b/tests/integration/Additional.integration.ts
@@ -69,7 +69,7 @@ export async function testAdditional(role: string) {
         });
 
         const fieldsets = within(container).getAllByRole('group');
-        expect(fieldsets).toHaveLength(1);
+        expect(fieldsets.length).toBeGreaterThan(0);
 
         await userEvent.click(screen.getByTitle('32_Lineage.add'));
         await tick();
@@ -79,19 +79,38 @@ export async function testAdditional(role: string) {
           expect(screen.queryAllByRole('group', { name: 'delete' }).length).toBeGreaterThan(0);
         });
 
-        const fieldset = within(container).getAllByRole('group')[2];
+        const titleFieldset = (
+          document.querySelector('#isoMetadata\\.lineage-0-title') as HTMLInputElement
+        )?.closest('fieldset') as HTMLElement;
 
         //TODO: Add test for search-input field like title
-
-        await testField('isoMetadata.lineage[0].date', {
-          fieldset: fieldset,
-          fieldInput: 'Test Date',
+        await testField('isoMetadata.lineage[0].title', {
+          fieldset: titleFieldset,
+          fieldInput: 'Test Title',
+          expectPersist: false,
           help: true
         });
 
+        const dateFieldset = (
+          document.querySelector('#isoMetadata\\.lineage-0-date') as HTMLInputElement
+        )?.closest('fieldset') as HTMLElement;
+
+        await testField('isoMetadata.lineage[0].date', {
+          fieldset: dateFieldset,
+          fieldType: 'date',
+          fieldInput: '2026-01-01',
+          expectPersist: false,
+          help: true
+        });
+
+        const identifierFieldset = (
+          document.querySelector('#isoMetadata\\.lineage-0-identifier') as HTMLInputElement
+        )?.closest('fieldset') as HTMLElement;
+
         await testField('isoMetadata.lineage[0].identifier', {
-          fieldset: fieldset,
+          fieldset: identifierFieldset,
           fieldInput: 'Test Identifier',
+          expectPersist: false,
           help: true
         });
 
@@ -99,12 +118,11 @@ export async function testAdditional(role: string) {
         await tick();
         await new Promise((r) => setTimeout(r, 0));
 
-        const inputFields = within(
-          document.querySelector('.lineages-field') as HTMLElement
-        ).getAllByRole('group');
-
         await waitFor(() => {
-          expect(inputFields).toHaveLength(9);
+          const inputFields = within(
+            document.querySelector('.lineages-field') as HTMLElement
+          ).getAllByRole('group');
+          expect(inputFields.length).toBeGreaterThanOrEqual(5);
         });
       });
     });

--- a/tests/integration/Basedata.integration.ts
+++ b/tests/integration/Basedata.integration.ts
@@ -101,7 +101,8 @@ export async function testBasedata(role: string) {
           testProgress: {
             section: 'basedata',
             label: 'form.basedata',
-            expectIncrease: isRequiredField('isoMetadata.keywords', 'basedata')
+            expectIncrease:
+              role === 'MdeAdministrator' && isRequiredField('isoMetadata.keywords', 'basedata')
           }
         });
 
@@ -169,22 +170,16 @@ export async function testBasedata(role: string) {
         });
 
         const popconfirm = document.querySelector('.popconfirm') as HTMLDialogElement;
+        const previousCallCount = fetchMock.mock.calls.length;
 
         await userEvent.click(within(popconfirm).getByText('19_ContactsField.delete'));
         await tick();
         await new Promise((r) => setTimeout(r, 0));
 
         await waitFor(() => {
-          expect(fetchMock).toHaveBeenCalledWith(expect.any(URL), {
-            method: 'PATCH',
-            body: JSON.stringify({
-              key: 'isoMetadata.pointsOfContact',
-              value: []
-            }),
-            headers: {
-              'content-type': 'application/json'
-            }
-          });
+          const calls = fetchMock.mock.calls.slice(previousCallCount);
+          const patchCall = calls.find(([, init]) => init?.method === 'PATCH');
+          expect(patchCall).toBeUndefined();
         });
 
         await waitFor(async () => {
@@ -202,6 +197,7 @@ export async function testBasedata(role: string) {
               fieldKey: 'isoMetadata.pointsOfContact[0].name',
               fieldType: 'text',
               fieldInput: 'John Doe',
+              expectPersist: false,
               fieldsetSelector: () =>
                 (
                   document.querySelector(
@@ -213,6 +209,7 @@ export async function testBasedata(role: string) {
               fieldKey: 'isoMetadata.pointsOfContact[0].organisation',
               fieldType: 'text',
               fieldInput: 'Test Organisation',
+              expectPersist: false,
               fieldsetSelector: () =>
                 (
                   document.querySelector(
@@ -224,6 +221,7 @@ export async function testBasedata(role: string) {
               fieldKey: 'isoMetadata.pointsOfContact[0].phone',
               fieldType: 'text',
               fieldInput: '+49-123-0123',
+              expectPersist: false,
               fieldsetSelector: () =>
                 (
                   document.querySelector(
@@ -256,6 +254,7 @@ export async function testBasedata(role: string) {
         const contactBtn = screen.getByRole('button', {
           name: '19_ContactsField.autofill'
         });
+        const previousCallCount = fetchMock.mock.calls.length;
 
         fireEvent.click(contactBtn);
         await tick();
@@ -271,13 +270,9 @@ export async function testBasedata(role: string) {
         });
 
         await waitFor(() => {
-          expect(fetchMock).toHaveBeenCalledWith(expect.any(URL), {
-            method: 'PATCH',
-            body: expect.stringContaining('"key":"isoMetadata.pointsOfContact"'),
-            headers: {
-              'content-type': 'application/json'
-            }
-          });
+          const calls = fetchMock.mock.calls.slice(previousCallCount);
+          const patchCall = calls.find(([, init]) => init?.method === 'PATCH');
+          expect(patchCall).toBeUndefined();
         });
       });
     });

--- a/tests/integration/Form.integration.spec.ts
+++ b/tests/integration/Form.integration.spec.ts
@@ -4,11 +4,6 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 
 import metadata3 from '../fixtures/metadata3';
 import FormHarness from '../helpers/FormHarness.svelte';
-import { testBasedata } from './Basedata.integration';
-import { testClassification } from './Classification.integration';
-import { testTempAndSpatial } from './TempAndSpatial.integration';
-import { testAdditional } from './Additional.integration';
-import { testServices } from './Services.integration';
 import { tick } from 'svelte';
 
 describe('Form - Integration test', () => {
@@ -47,29 +42,5 @@ describe('Form - Integration test', () => {
         ).toBeInTheDocument();
       });
     });
-  });
-
-  describe('Form completion with role MdeAdministrator', () => {
-    testBasedata('MdeAdministrator');
-    testClassification('MdeAdministrator');
-    testTempAndSpatial('MdeAdministrator');
-    testAdditional('MdeAdministrator');
-    testServices('MdeAdministrator');
-  });
-
-  describe('Form completion with role MdeEditor', () => {
-    testBasedata('MdeEditor');
-    testClassification('MdeEditor');
-    testTempAndSpatial('MdeEditor');
-    testAdditional('MdeEditor');
-    testServices('MdeEditor');
-  });
-
-  describe('Form completion with role MdeDataOwner', () => {
-    testBasedata('MdeDataOwner');
-    testClassification('MdeDataOwner');
-    testTempAndSpatial('MdeDataOwner');
-    testAdditional('MdeDataOwner');
-    testServices('MdeDataOwner');
   });
 });

--- a/tests/integration/FormAdministrator.integration.spec.ts
+++ b/tests/integration/FormAdministrator.integration.spec.ts
@@ -1,0 +1,24 @@
+import { cleanup } from '@testing-library/svelte';
+import { afterEach, describe, vi } from 'vitest';
+import { tick } from 'svelte';
+
+import { testAdditional } from './Additional.integration';
+import { testBasedata } from './Basedata.integration';
+import { testClassification } from './Classification.integration';
+import { testServices } from './Services.integration';
+import { testTempAndSpatial } from './TempAndSpatial.integration';
+
+describe('Form completion with role MdeAdministrator', () => {
+  afterEach(async () => {
+    await tick();
+    await Promise.resolve();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  testBasedata('MdeAdministrator');
+  testClassification('MdeAdministrator');
+  testTempAndSpatial('MdeAdministrator');
+  testAdditional('MdeAdministrator');
+  testServices('MdeAdministrator');
+});

--- a/tests/integration/FormDataOwner.integration.spec.ts
+++ b/tests/integration/FormDataOwner.integration.spec.ts
@@ -1,0 +1,24 @@
+import { cleanup } from '@testing-library/svelte';
+import { afterEach, describe, vi } from 'vitest';
+import { tick } from 'svelte';
+
+import { testAdditional } from './Additional.integration';
+import { testBasedata } from './Basedata.integration';
+import { testClassification } from './Classification.integration';
+import { testServices } from './Services.integration';
+import { testTempAndSpatial } from './TempAndSpatial.integration';
+
+describe('Form completion with role MdeDataOwner', () => {
+  afterEach(async () => {
+    await tick();
+    await Promise.resolve();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  testBasedata('MdeDataOwner');
+  testClassification('MdeDataOwner');
+  testTempAndSpatial('MdeDataOwner');
+  testAdditional('MdeDataOwner');
+  testServices('MdeDataOwner');
+});

--- a/tests/integration/FormEditor.integration.spec.ts
+++ b/tests/integration/FormEditor.integration.spec.ts
@@ -1,0 +1,24 @@
+import { cleanup } from '@testing-library/svelte';
+import { afterEach, describe, vi } from 'vitest';
+import { tick } from 'svelte';
+
+import { testAdditional } from './Additional.integration';
+import { testBasedata } from './Basedata.integration';
+import { testClassification } from './Classification.integration';
+import { testServices } from './Services.integration';
+import { testTempAndSpatial } from './TempAndSpatial.integration';
+
+describe('Form completion with role MdeEditor', () => {
+  afterEach(async () => {
+    await tick();
+    await Promise.resolve();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  testBasedata('MdeEditor');
+  testClassification('MdeEditor');
+  testTempAndSpatial('MdeEditor');
+  testAdditional('MdeEditor');
+  testServices('MdeEditor');
+});

--- a/tests/integration/Services.integration.ts
+++ b/tests/integration/Services.integration.ts
@@ -279,6 +279,7 @@ export async function testServices(role: string) {
               fieldset: fieldset,
               fieldType: 'text',
               fieldInput: 'New FeatureType Title',
+              expectPersist: false,
               help: true,
               testProgress: {
                 section: 'services',
@@ -302,6 +303,7 @@ export async function testServices(role: string) {
                 fieldset: fieldset,
                 fieldType: 'text',
                 fieldInput: 'New FeatureType Name',
+                expectPersist: false,
                 help: true,
                 testProgress: {
                   section: 'services',
@@ -338,6 +340,7 @@ export async function testServices(role: string) {
               fieldType: 'text',
               fieldInput: 'New featureType Description...',
               requiredMessage: 'Bitte geben Sie eine Kurzbeschreibung für den FeatureType an.',
+              expectPersist: false,
               help: true,
               testProgress: {
                 section: 'services',
@@ -375,6 +378,7 @@ export async function testServices(role: string) {
                 fieldset: fieldset,
                 fieldType: 'text',
                 fieldInput: 'New FeatureType Name',
+                expectPersist: false,
                 help: true,
                 testProgress: {
                   section: 'services',
@@ -397,6 +401,7 @@ export async function testServices(role: string) {
                 fieldset: fieldset,
                 fieldType: 'text',
                 fieldInput: 'New FeatureType Alias',
+                expectPersist: false,
                 help: true,
                 testProgress: {
                   section: 'services',

--- a/tests/integration/TempAndSpatial.integration.ts
+++ b/tests/integration/TempAndSpatial.integration.ts
@@ -290,6 +290,7 @@ export async function testTempAndSpatial(role: string) {
           fieldset: fieldset,
           fieldType: 'radio',
           radioOptionKey: 'isoMetadata.resolutions',
+          expectPersist: false,
           help: true,
           testProgress: {
             section: 'temp_and_spatial',

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -60,6 +60,23 @@ function mockJson(data: unknown) {
   return Promise.resolve(createResponse() as Response);
 }
 
+function applyPathValue(target: any, path: string, value: unknown) {
+  const keys = path.replace(/\[(\d+)\]/g, '.$1').split('.');
+  let current = target;
+
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    const nextKey = keys[i + 1];
+
+    if (!current[key]) {
+      current[key] = /^\d+$/.test(nextKey) ? [] : {};
+    }
+    current = current[key];
+  }
+
+  current[keys[keys.length - 1]] = value;
+}
+
 export const fetchMock = vi.fn(async (input: string | Request | URL, init?: RequestInit) => {
   const url = input.toString();
 
@@ -180,18 +197,6 @@ export const fetchMock = vi.fn(async (input: string | Request | URL, init?: Requ
       const body = JSON.parse(init.body as string);
 
       if (body.key && body.value !== undefined) {
-        const keys = body.key.split('.');
-        let current: any = currentMetadata;
-
-        for (let i = 0; i < keys.length - 1; i++) {
-          if (!current[keys[i]]) {
-            current[keys[i]] = {};
-          }
-          current = current[keys[i]];
-        }
-
-        const lastKey = keys[keys.length - 1];
-
         let value = body.value;
         if (typeof value === 'string') {
           try {
@@ -201,7 +206,7 @@ export const fetchMock = vi.fn(async (input: string | Request | URL, init?: Requ
           }
         }
 
-        current[lastKey] = value;
+        applyPathValue(currentMetadata, body.key, value);
       } else if (!body.key) {
         Object.keys(body).forEach((key) => {
           if (


### PR DESCRIPTION
See also [#29089](https://redmine.intranet.terrestris.de/issues/29089) and [#29500](https://redmine.intranet.terrestris.de/issues/29500).

This PR reapplies the changes (by cherry-picking) that were reverted in https://github.com/gdi-be/mde-client/pull/287 for `6.1.x` to the `main`/`6.2.x` branch and adapts them for the new Svelte version.

In addition, the tests have been updated to reflect the components' changed behavior with these changes. The large form integration test file was split by role so vitest can release memory between suites and the CI run no longer fails with an out-of-memory error.