### PR TITLE
Fieldset persistance logic (#29500)

### DIFF
--- a/src/lib/components/Form/Field/12_ValidityRangeField.svelte
+++ b/src/lib/components/Form/Field/12_ValidityRangeField.svelte
@@ -11,7 +11,7 @@
   const FROM_KEY = 'isoMetadata.validFrom';
   const TO_KEY = 'isoMetadata.validTo';
 
-  const { getValue, formState } = getFormContext();
+  const { getValue, updateFormState } = getFormContext();
   const startValueFromData = $derived(getValue<string>(FROM_KEY));
   let startValue = $state('');
   let startInitialized = false;
@@ -51,18 +51,15 @@
   const toFieldConfig = MetadataService.getFieldConfig<string>(24);
   let toValidationResult = $derived(toFieldConfig?.validator(endValue, [startValue]));
 
+  const syncLocalValue = () => {
+    updateFormState(FROM_KEY, startValue ? new Date(startValue).toISOString() : null);
+    updateFormState(TO_KEY, endValue ? new Date(endValue).toISOString() : null);
+  };
+
   const onBlur = async (key: string) => {
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          validFrom: startValue ? new Date(startValue).toISOString() : null,
-          validTo: endValue ? new Date(endValue).toISOString() : null
-        }
-      };
-    }
-    if (hasInvalidFields) {
+    syncLocalValue();
+    const validationResult = key === FROM_KEY ? fromValidationResult : toValidationResult;
+    if (validationResult?.valid === false) {
       return;
     }
     const value = key === FROM_KEY ? startValue : endValue!;
@@ -81,16 +78,7 @@
     } else {
       endValue = inputValue;
     }
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          validFrom: startValue ? new Date(startValue).toISOString() : null,
-          validTo: endValue ? new Date(endValue).toISOString() : null
-        }
-      };
-    }
+    syncLocalValue();
   };
 
   let hasInvalidFields = $derived.by(() => {

--- a/src/lib/components/Form/Field/15_KeywordsField.svelte
+++ b/src/lib/components/Form/Field/15_KeywordsField.svelte
@@ -24,7 +24,20 @@
   let { metadataid } = page.params;
 
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
-  let value = $state<string[]>([]);
+  const getKeywordText = (keyword: unknown) => {
+    if (typeof keyword === 'string') return keyword.trim();
+    if (keyword && typeof keyword === 'object' && 'keyword' in keyword) {
+      const value = (keyword as { keyword?: unknown }).keyword;
+      return typeof value === 'string' ? value.trim() : '';
+    }
+    return '';
+  };
+  const fromKeywords = (keywords?: Keywords) =>
+    Array.from(new Set((keywords?.default || []).map(getKeywordText).filter(Boolean)));
+
+  let value = $state<string[]>(
+    fromKeywords(MetadataService.getValue<Keywords>(KEY, formState.metadata))
+  );
 
   let showCheckmark = $state(false);
   let autoKeywords = $state<string[]>([]);
@@ -33,7 +46,9 @@
   let searchValue = $state('');
   const fieldConfig = MetadataService.getFieldConfig<Keywords>(15);
   const toKeywords = (keywords: string[]): Keywords => ({
-    default: keywords.map((entry) => ({ keyword: entry }))
+    default: Array.from(new Set(keywords.map(getKeywordText).filter(Boolean))).map((entry) => ({
+      keyword: entry
+    }))
   });
   let validationResult = $derived(fieldConfig?.validator(toKeywords(value)));
 
@@ -82,7 +97,9 @@
   };
 
   const addSelectedKeyword = ({ detail }: CustomEvent) => {
-    value = Array.from(new Set([...value, detail]));
+    const keyword = getKeywordText(detail);
+    if (!keyword) return;
+    value = Array.from(new Set([...value, keyword]));
     searchValue = '';
     persistKeywords();
   };
@@ -90,7 +107,10 @@
   const addCustomKeywords = () => {
     if (newKeyword) {
       // split by comma and remove leading/trailing whitespaces
-      const splitValues = newKeyword.split(',').map((kw) => kw.trim());
+      const splitValues = newKeyword
+        .split(',')
+        .map((kw) => kw.trim())
+        .filter(Boolean);
       // ensure unique values
       value = Array.from(new Set([...value, ...splitValues]));
       dialogOpen = false;

--- a/src/lib/components/Form/Field/18_ExtentField.svelte
+++ b/src/lib/components/Form/Field/18_ExtentField.svelte
@@ -2,11 +2,11 @@
   import { getFormContext } from '$lib/context/FormContext.svelte';
   import FieldTools from '../FieldTools.svelte';
   import FieldHint from '../FieldHint.svelte';
-  import type { CRS, PartialExtent } from '$lib/models/metadata';
+  import type { CRS, PartialCoordinate, PartialExtent } from '$lib/models/metadata';
   import { MetadataService } from '$lib/services/MetadataService';
   import Button, { Icon, Label } from '@smui/button';
   import SelectInput from '../Inputs/SelectInput.svelte';
-  import { getHighestRole, registerCRSCodes, transformExtent } from '$lib/util';
+  import { getHighestRole, registerCRSCodes, transformCoordinate } from '$lib/util';
   import { onMount, tick } from 'svelte';
   import { toast } from 'svelte-french-toast';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
@@ -41,13 +41,14 @@
   const token = $derived(getAccessToken());
   const highestRole = $derived(getHighestRole(token));
 
-  const { getValue } = getFormContext();
+  const { getValue, updateFormState } = getFormContext();
   let initialCRSKey = getValue<CRS>(CRS_KEY);
   const valueFromData = $derived(getValue<PartialExtent>(KEY));
   let value4326 = $state<PartialExtent>(emptyExtent);
+  let isEditing = $state(false);
 
   $effect(() => {
-    if (valueFromData) {
+    if (!isEditing && valueFromData) {
       value4326 = valueFromData;
     }
   });
@@ -56,8 +57,11 @@
   let crsOptions = $state<CRSOption[]>([]);
   let crsKey = $state(initialCRSKey);
   let crs = $derived(crsOptions.find((option) => option.key === crsKey));
+  let selectedCRS = $derived((crs?.label as CRS) || 'EPSG:4326');
   let showCheckmark = $state(false);
   let inputValue = $state<PartialExtent>(emptyExtent);
+  let pendingInputKeys = $state<(keyof PartialExtent)[]>([]);
+  let pendingInputValue = $state<PartialExtent>(emptyExtent);
   let matchingOption = $derived(
     extentOptions.find((option) => {
       return (
@@ -73,13 +77,13 @@
     ValidationService.validateField(minXFieldConfig, inputValue.minx)
   );
   let validationResultMinY = $derived(
-    ValidationService.validateField(minXFieldConfig, inputValue.miny)
+    ValidationService.validateField(minYFieldConfig, inputValue.miny)
   );
   let validationResultMaxX = $derived(
-    ValidationService.validateField(minXFieldConfig, inputValue.maxx)
+    ValidationService.validateField(maxXFieldConfig, inputValue.maxx)
   );
   let validationResultMaxY = $derived(
-    ValidationService.validateField(minXFieldConfig, inputValue.maxy)
+    ValidationService.validateField(maxYFieldConfig, inputValue.maxy)
   );
 
   let hasInvalidFields = $derived(
@@ -89,10 +93,87 @@
       validationResultMaxY?.valid === false
   );
 
+  const fieldConfigByKey = {
+    minx: minXFieldConfig,
+    miny: minYFieldConfig,
+    maxx: maxXFieldConfig,
+    maxy: maxYFieldConfig
+  };
+
+  const pairByKey = {
+    minx: ['minx', 'miny'],
+    miny: ['minx', 'miny'],
+    maxx: ['maxx', 'maxy'],
+    maxy: ['maxx', 'maxy']
+  } satisfies Record<keyof PartialExtent, [keyof PartialExtent, keyof PartialExtent]>;
+
+  const toCoordinate = (
+    extent: PartialExtent,
+    [xKey, yKey]: [keyof PartialExtent, keyof PartialExtent]
+  ) => [extent[xKey], extent[yKey]] as PartialCoordinate;
+
+  const hasCoordinate = (coordinate: PartialCoordinate) =>
+    coordinate.every((value) => value !== undefined && Number.isFinite(value));
+
+  const addPendingInputKey = (key: keyof PartialExtent, value: number | undefined) => {
+    pendingInputKeys = pendingInputKeys.includes(key)
+      ? pendingInputKeys
+      : [...pendingInputKeys, key];
+    pendingInputValue = {
+      ...pendingInputValue,
+      [key]: value
+    };
+  };
+
+  const removePendingInputKeys = (keys: (keyof PartialExtent)[]) => {
+    pendingInputKeys = pendingInputKeys.filter((key) => !keys.includes(key));
+    pendingInputValue = {
+      ...pendingInputValue,
+      ...Object.fromEntries(keys.map((key) => [key, undefined]))
+    };
+  };
+
+  const transformCoordinatePair = (
+    extent: PartialExtent,
+    pair: [keyof PartialExtent, keyof PartialExtent],
+    from: CRS,
+    to: CRS
+  ) => {
+    const coordinate = toCoordinate(extent, pair);
+    if (!hasCoordinate(coordinate)) return {};
+
+    if (from === to) {
+      return {
+        [pair[0]]: coordinate[0],
+        [pair[1]]: coordinate[1]
+      };
+    }
+
+    const transformed = transformCoordinate(coordinate, from, to);
+    return {
+      [pair[0]]: coordinate[0] === 0 ? 0 : transformed[0],
+      [pair[1]]: coordinate[1] === 0 ? 0 : transformed[1]
+    };
+  };
+
+  const transformAvailableExtent = (extent: PartialExtent, from: CRS, to: CRS) => {
+    if (from === to) return extent;
+
+    return {
+      ...transformCoordinatePair(extent, pairByKey.minx, from, to),
+      ...transformCoordinatePair(extent, pairByKey.maxx, from, to)
+    };
+  };
+
   $effect(() => {
+    if (isEditing) return;
+
     try {
-      const newTransformedValue = transformExtent(value4326, 'EPSG:4326', crs?.label as CRS);
-      inputValue = newTransformedValue;
+      const transformedValue = transformAvailableExtent(value4326, 'EPSG:4326', selectedCRS);
+      inputValue = {
+        ...transformedValue,
+        ...Object.fromEntries(pendingInputKeys.map((key) => [key, pendingInputValue[key]]))
+      };
     } catch {
       logger.error(t('18_ExtentField.error_transforming_coordinates_from_server'), {
         value4326,
@@ -101,27 +182,92 @@
     }
   });
 
-  const onChange = (newValue: number, key: keyof PartialExtent) => {
-    const newTransformedValue = {
-      ...inputValue,
+  const getInputValue = (target: HTMLInputElement) => {
+    const value = target.value.trim();
+    return value === '' ? undefined : Number(value);
+  };
+
+  const normalizeCoordinateValue = (value: unknown) => {
+    if (value === '' || value === undefined || value === null) return undefined;
+    return Number(value);
+  };
+
+  const normalizeInputValue = (extent: PartialExtent): PartialExtent => ({
+    minx: normalizeCoordinateValue(extent.minx),
+    miny: normalizeCoordinateValue(extent.miny),
+    maxx: normalizeCoordinateValue(extent.maxx),
+    maxy: normalizeCoordinateValue(extent.maxy)
+  });
+
+  const isValidInput = (key: keyof PartialExtent, currentInputValue: PartialExtent) =>
+    ValidationService.validateField(fieldConfigByKey[key], currentInputValue[key])?.valid === true;
+
+  const onChange = (newValue: number | undefined, key: keyof PartialExtent) => {
+    const newInputValue = {
+      ...normalizeInputValue(inputValue),
       [key]: newValue
     };
+    inputValue = newInputValue;
+    if (pendingInputKeys.includes(key)) {
+      pendingInputValue = {
+        ...pendingInputValue,
+        [key]: newValue
+      };
+    }
+
+    const validation = ValidationService.validateField(fieldConfigByKey[key], newValue);
+    if (validation?.valid !== true) {
+      return;
+    }
+
+    const pair = pairByKey[key];
+    if (!hasCoordinate(toCoordinate(newInputValue, pair))) {
+      if (selectedCRS === 'EPSG:4326') {
+        const newValue4326 = {
+          ...value4326,
+          [key]: newValue
+        };
+        value4326 = newValue4326;
+        sendValue(newInputValue, newValue4326);
+      } else {
+        addPendingInputKey(key, newValue);
+      }
+      return;
+    }
+
     try {
-      value4326 = transformExtent(newTransformedValue, crs?.label as CRS, 'EPSG:4326');
-      sendValue();
+      const newValue4326 = {
+        ...value4326,
+        ...transformCoordinatePair(newInputValue, pair, selectedCRS, 'EPSG:4326')
+      };
+      value4326 = newValue4326;
+      removePendingInputKeys([...pair]);
+      sendValue(newInputValue, newValue4326);
     } catch {
       toast.error(t('18_ExtentField.error_transforming_coordinates', { key }));
     }
   };
 
-  const sendValue = async () => {
-    if (hasInvalidFields) {
-      return;
-    }
-    const response = await MetadataService.persistValue(KEY, value4326);
+  const sendValue = async (currentInputValue = inputValue, currentValue4326 = value4326) => {
+    const persistableExtent = getPersistableExtent(currentInputValue, currentValue4326);
+    updateFormState(KEY, persistableExtent);
+
+    const response = await MetadataService.persistValue(KEY, persistableExtent);
     if (response.ok) {
       showCheckmark = true;
     }
+  };
+
+  const getPersistableExtent = (
+    currentInputValue: PartialExtent,
+    currentValue4326: PartialExtent
+  ) => {
+    return {
+      minx: isValidInput('minx', currentInputValue) ? currentValue4326.minx : valueFromData?.minx,
+      miny: isValidInput('miny', currentInputValue) ? currentValue4326.miny : valueFromData?.miny,
+      maxx: isValidInput('maxx', currentInputValue) ? currentValue4326.maxx : valueFromData?.maxx,
+      maxy: isValidInput('maxy', currentInputValue) ? currentValue4326.maxy : valueFromData?.maxy
+    };
   };
 
   onMount(async () => {
@@ -160,6 +306,8 @@
             title={option.title}
             onclick={async () => {
               value4326 = option.value;
+              pendingInputKeys = [];
+              pendingInputValue = emptyExtent;
               await tick();
               sendValue();
             }}
@@ -174,48 +322,56 @@
           <TextInput
             label={t('18_ExtentField.label_min_x')}
             fieldConfig={minXFieldConfig}
-            bind:value={inputValue.minx}
+            value={inputValue.minx}
             onchange={(evt) => {
               const target = evt?.target as HTMLInputElement;
-              onChange(Number(target.value), 'minx');
+              onChange(getInputValue(target), 'minx');
             }}
             step={['EPSG:4326', 'EPSG:4258'].includes(crs?.label as CRS) ? '0.0001' : undefined}
             validationResult={validationResultMinX}
+            onfocus={() => (isEditing = true)}
+            onblur={() => (isEditing = false)}
           />
           <TextInput
-            bind:value={inputValue.maxx}
+            value={inputValue.maxx}
             label={t('18_ExtentField.label_max_x')}
             fieldConfig={maxXFieldConfig}
             onchange={(evt) => {
               const target = evt?.target as HTMLInputElement;
-              onChange(Number(target.value), 'maxx');
+              onChange(getInputValue(target), 'maxx');
             }}
             step={['EPSG:4326', 'EPSG:4258'].includes(crs?.label as CRS) ? '0.0001' : undefined}
             validationResult={validationResultMaxX}
+            onfocus={() => (isEditing = true)}
+            onblur={() => (isEditing = false)}
           />
         </div>
         <div class="inline-fields">
           <TextInput
-            bind:value={inputValue.miny}
+            value={inputValue.miny}
             label={t('18_ExtentField.label_min_y')}
             fieldConfig={minYFieldConfig}
             onchange={(evt) => {
               const target = evt?.target as HTMLInputElement;
-              onChange(Number(target.value), 'miny');
+              onChange(getInputValue(target), 'miny');
             }}
             step={['EPSG:4326', 'EPSG:4258'].includes(crs?.label as CRS) ? '0.0001' : undefined}
             validationResult={validationResultMinY}
+            onfocus={() => (isEditing = true)}
+            onblur={() => (isEditing = false)}
           />
           <TextInput
-            bind:value={inputValue.maxy}
+            value={inputValue.maxy}
             label={t('18_ExtentField.label_max_y')}
             fieldConfig={maxYFieldConfig}
             onchange={(evt) => {
               const target = evt?.target as HTMLInputElement;
-              onChange(Number(target.value), 'maxy');
+              onChange(getInputValue(target), 'maxy');
             }}
             step={['EPSG:4326', 'EPSG:4258'].includes(crs?.label as CRS) ? '0.0001' : undefined}
             validationResult={validationResultMaxY}
+            onfocus={() => (isEditing = true)}
+            onblur={() => (isEditing = false)}
           />
         </div>
       </div>

--- a/src/lib/components/Form/Field/19_ContactsField.svelte
+++ b/src/lib/components/Form/Field/19_ContactsField.svelte
@@ -14,6 +14,7 @@
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
   import { getContext } from 'svelte';
+  import { getPersistableItems } from '../persistableItems';
 
   const t = $derived(page.data.t);
 
@@ -22,13 +23,14 @@
 
   const KEY = 'isoMetadata.pointsOfContact';
 
-  const { getValue } = getFormContext();
+  const { getValue, updateFormState } = getFormContext();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   let contacts = $state<Contact[]>([]);
   const valueFromData = $derived(getValue<Contacts>(KEY));
 
   // important that this is not a state
   let previousValueAsString: string;
+  let lastPersistedContacts = $state<Contacts>([]);
   let hasUnsavedLocalChange = $state(false);
 
   const popconfirm = $derived(getPopconfirm());
@@ -57,6 +59,7 @@
         };
       }) || [];
     previousValueAsString = JSON.stringify(valueFromData);
+    lastPersistedContacts = valueFromData || [];
   });
 
   let showCheckmark = $state(false);
@@ -90,26 +93,22 @@
     persistContacts();
   };
 
-  const persistContacts = async (evt?: FocusEvent) => {
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          pointsOfContact: contacts
-        }
-      };
-    }
+  const persistContacts = async (evt?: FocusEvent, fieldIsValid = true) => {
+    const persistableContacts = getPersistableContacts();
+    updateFormState(KEY, contacts);
 
-    if (hasInvalidFields) {
+    if (!fieldIsValid) {
       return;
     }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;
-    const response = await MetadataService.persistValue(KEY, contacts);
+    const response = await MetadataService.persistValue(KEY, persistableContacts);
     if (response.ok) {
-      hasUnsavedLocalChange = false;
+      lastPersistedContacts = persistableContacts;
+      updateFormState(KEY, contacts);
+      previousValueAsString = JSON.stringify(contacts);
+      hasUnsavedLocalChange = JSON.stringify(contacts) !== JSON.stringify(persistableContacts);
       showCheckmark = true;
     }
 
@@ -118,6 +117,18 @@
       const elementToFocus = document.getElementById(focusedElement.id);
       elementToFocus?.focus();
     }, 10);
+  };
+
+  const getPersistableContacts = () => {
+    return getPersistableItems(contacts, lastPersistedContacts, [
+      { key: 'name', isValid: (contact) => nameConfig?.validator(contact.name)?.valid === true },
+      {
+        key: 'organisation',
+        isValid: (contact) => organisationConfig?.validator(contact.organisation)?.valid === true
+      },
+      { key: 'phone', isValid: (contact) => phoneConfig?.validator(contact.phone)?.valid === true },
+      { key: 'email', isValid: (contact) => emailConfig?.validator(contact.email)?.valid === true }
+    ]);
   };
 
   const addItem = (evt?: MouseEvent) => {
@@ -133,7 +144,7 @@
       },
       ...contacts
     ];
-    persistContacts();
+    updateFormState(KEY, contacts);
   };
 
   const removeItem = (id: string, evt: MouseEvent) => {
@@ -154,15 +165,7 @@
 
   const onContactChange = () => {
     hasUnsavedLocalChange = true;
-    if (formState.metadata?.isoMetadata) {
-      formState.metadata = {
-        ...formState.metadata,
-        isoMetadata: {
-          ...formState.metadata.isoMetadata,
-          pointsOfContact: contacts
-        }
-      };
-    }
+    updateFormState(KEY, contacts);
   };
 
   $effect(() => {
@@ -174,13 +177,7 @@
     if (serverValue === localValue) {
       return;
     }
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        pointsOfContact: contacts
-      }
-    };
+    updateFormState(KEY, contacts);
   });
 
   let hasInvalidFields = $derived.by(() => {
@@ -190,12 +187,12 @@
       highestRole === 'MdeAdministrator' ||
       (editingRoles ? editingRoles?.includes(highestRole) : true);
     const hasInvalidFields = contacts.some((contact) => {
-      const nameValid = nameConfig?.validator(contact.name).valid ?? true;
+      const nameValid = nameConfig?.validator(contact.name)?.valid ?? true;
       const organisationValid = organisationConfig
-        ? organisationConfig?.validator(contact.organisation).valid
+        ? organisationConfig?.validator(contact.organisation)?.valid
         : true;
-      const phoneValid = phoneConfig ? phoneConfig?.validator(contact.phone).valid : true;
-      const emailValid = emailConfig ? emailConfig?.validator(contact.email).valid : true;
+      const phoneValid = phoneConfig ? phoneConfig?.validator(contact.phone)?.valid : true;
+      const emailValid = emailConfig ? emailConfig?.validator(contact.email)?.valid : true;
       return !nameValid || !organisationValid || !phoneValid || !emailValid;
     });
     return isEditingRole && (!validationResult?.valid || hasInvalidFields);
@@ -235,7 +232,8 @@
             bind:value={contact.name}
             label={t('19_ContactsField.name')}
             onchange={onContactChange}
-            onblur={persistContacts}
+            onblur={(evt) =>
+              persistContacts(evt, nameConfig?.validator(contact.name)?.valid === true)}
             fieldConfig={nameConfig}
             validationResult={nameConfig?.validator(contact.name)}
             id={`${KEY}-${index}-name`}
@@ -253,7 +251,11 @@
             bind:value={contact.organisation}
             label={t('19_ContactsField.organisation')}
             onchange={onContactChange}
-            onblur={persistContacts}
+            onblur={(evt) =>
+              persistContacts(
+                evt,
+                organisationConfig?.validator(contact.organisation)?.valid === true
+              )}
             fieldConfig={organisationConfig}
             validationResult={organisationConfig?.validator(contact.organisation)}
             id={`${KEY}-${index}-organisation`}
@@ -271,7 +273,8 @@
             bind:value={contact.phone}
             label={t('19_ContactsField.phone')}
             onchange={onContactChange}
-            onblur={persistContacts}
+            onblur={(evt) =>
+              persistContacts(evt, phoneConfig?.validator(contact.phone)?.valid === true)}
             fieldConfig={phoneConfig}
             validationResult={phoneConfig?.validator(contact.phone)}
             id={`${KEY}-${index}-phone`}
@@ -289,7 +292,8 @@
             bind:value={contact.email}
             label={t('19_ContactsField.email')}
             onchange={onContactChange}
-            onblur={persistContacts}
+            onblur={(evt) =>
+              persistContacts(evt, emailConfig?.validator(contact.email)?.valid === true)}
             fieldConfig={emailConfig}
             validationResult={emailConfig?.validator(contact.email)}
             id={`${KEY}-${index}-email`}

--- a/src/lib/components/Form/Field/32_Lineage.svelte
+++ b/src/lib/components/Form/Field/32_Lineage.svelte
@@ -14,6 +14,7 @@
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
   import { getContext } from 'svelte';
+  import { getPersistableItems } from '../persistableItems';
 
   const t = $derived(page.data.t);
 
@@ -22,7 +23,7 @@
 
   const KEY = 'isoMetadata.lineage';
 
-  const { getValue } = getFormContext();
+  const { getValue, updateFormState } = getFormContext();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<Lineage[]>(KEY));
   let lineages = $state<Lineage[]>([]);
@@ -43,8 +44,13 @@
 
   // important that this is not a state
   let previousValueAsString: string;
+  let lastPersistedLineages = $state<Lineage[]>([]);
+  let hasUnsavedLocalChange = $state(false);
 
   $effect(() => {
+    if (hasUnsavedLocalChange) {
+      return;
+    }
     // this check prevents rerendering if nothing has actually changed
     const newValueAsString = JSON.stringify(valueFromData);
     if (
@@ -63,11 +69,12 @@
       };
     });
     previousValueAsString = JSON.stringify(valueFromData);
+    lastPersistedLineages = valueFromData || [];
   });
 
   // add global click listener if titleSearchResults are open
   // to close the search results when clicking outside
-  $effect(() => {
+  $effect.pre(() => {
     if (metadataCollections.length > 0) {
       const closeSearchResults = () => {
         metadataCollections = [];
@@ -98,22 +105,35 @@
     return data?.content || [];
   };
 
-  const persistLineages = async (evt?: FocusEvent) => {
+  const persistLineages = async (evt?: FocusEvent, fieldIsValid = true) => {
     syncLocalLineageState();
+    const persistableLineages = getPersistableLineages();
 
-    if (hasInvalidFields) {
+    if (!fieldIsValid) {
       return;
     }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;
 
-    const value = lineages.map((lineage) => ({
+    const value = persistableLineages.map((lineage) => ({
       ...lineage,
-      date: lineage.date ? new Date(lineage.date).toISOString() : ''
+      date: lineage.date ? new Date(lineage.date).toISOString() : undefined
     }));
     const response = await MetadataService.persistValue(KEY, value);
     if (response.ok) {
+      lastPersistedLineages = value;
+      lineages = value.map((lineage: Lineage) => {
+        return {
+          id: lineage.id,
+          title: lineage.title || '',
+          identifier: lineage.identifier || '',
+          date: lineage.date ? new Date(lineage.date).toISOString().split('T')[0] : ''
+        };
+      });
+      updateFormState(KEY, value);
+      previousValueAsString = JSON.stringify(value);
+      hasUnsavedLocalChange = false;
       showCheckmark = true;
     }
 
@@ -122,6 +142,23 @@
       const elementToFocus = document.getElementById(focusedElement.id);
       elementToFocus?.focus();
     }, 10);
+  };
+
+  const getPersistableLineages = () => {
+    return getPersistableItems(lineages, lastPersistedLineages, [
+      {
+        key: 'title',
+        isValid: (lineage) => titleFieldConfig?.validator(lineage.title)?.valid === true
+      },
+      {
+        key: 'date',
+        isValid: (lineage) => dateFieldConfig?.validator(lineage.date)?.valid === true
+      },
+      {
+        key: 'identifier',
+        isValid: (lineage) => identifierFieldConfig?.validator(lineage.identifier)?.valid === true
+      }
+    ]);
   };
 
   const syncLocalLineageState = () => {
@@ -134,13 +171,8 @@
       return;
     }
 
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        lineage: lineages
-      }
-    };
+    hasUnsavedLocalChange = true;
+    updateFormState(KEY, lineages);
   };
 
   $effect(() => {
@@ -159,7 +191,7 @@
       },
       ...lineages
     ];
-    persistLineages();
+    syncLocalLineageState();
   };
 
   const removeItem = (id: string, evt: MouseEvent) => {
@@ -204,12 +236,12 @@
     titleSearchListId = lineage.id;
   };
 
-  const onTitleBlur = async (evt: FocusEvent) => {
+  const onTitleBlur = async (evt: FocusEvent, lineage: Lineage) => {
     const focusedElement = evt.relatedTarget as HTMLElement;
     if (searchResultsElement && focusedElement && searchResultsElement.contains(focusedElement)) {
       return;
     }
-    await persistLineages(evt);
+    await persistLineages(evt, titleFieldConfig?.validator(lineage.title)?.valid === true);
   };
 
   let hasInvalidFields = $derived.by(() => {
@@ -219,9 +251,9 @@
       highestRole === 'MdeAdministrator' ||
       (editingRoles ? editingRoles?.includes(highestRole) : true);
     const hasInvalidFields = lineages.some((lineage) => {
-      const titleValid = titleFieldConfig?.validator(lineage.title).valid ?? true;
-      const dateValid = dateFieldConfig?.validator(lineage.date).valid ?? true;
-      const identifierValid = identifierFieldConfig?.validator(lineage.identifier).valid ?? true;
+      const titleValid = titleFieldConfig?.validator(lineage.title)?.valid ?? true;
+      const dateValid = dateFieldConfig?.validator(lineage.date)?.valid ?? true;
+      const identifierValid = identifierFieldConfig?.validator(lineage.identifier)?.valid ?? true;
       return !titleValid || !dateValid || !identifierValid;
     });
     return isEditingRole && hasInvalidFields;
@@ -261,7 +293,7 @@
             <TextInput
               bind:value={lineage.title}
               label={t('32_Lineage.title')}
-              onblur={onTitleBlur}
+              onblur={(evt) => onTitleBlur(evt, lineage)}
               onkeyup={(evt) => onTitleKeyUp(evt, lineage)}
               fieldConfig={titleFieldConfig}
               validationResult={titleFieldConfig?.validator(lineage.title)}
@@ -294,7 +326,8 @@
               bind:value={lineage.date}
               key={KEY}
               label={t('32_Lineage.publish_date')}
-              onblur={persistLineages}
+              onblur={(evt) =>
+                persistLineages(evt, dateFieldConfig?.validator(lineage.date)?.valid === true)}
               fieldConfig={dateFieldConfig}
               validationResult={dateFieldConfig?.validator(lineage.date)}
               id={`${KEY}-${index}-date`}
@@ -305,7 +338,11 @@
             <TextInput
               bind:value={lineage.identifier}
               label={t('32_Lineage.identifier')}
-              onblur={persistLineages}
+              onblur={(evt) =>
+                persistLineages(
+                  evt,
+                  identifierFieldConfig?.validator(lineage.identifier)?.valid === true
+                )}
               fieldConfig={identifierFieldConfig}
               validationResult={identifierFieldConfig?.validator(lineage.identifier)}
               id={`${KEY}-${index}-identifier`}

--- a/src/lib/components/Form/Field/41_AdditionalInformation.svelte
+++ b/src/lib/components/Form/Field/41_AdditionalInformation.svelte
@@ -13,6 +13,7 @@
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
   import { getContext } from 'svelte';
+  import { getPersistableItems } from '../persistableItems';
 
   const t = $derived(page.data.t);
 
@@ -21,7 +22,7 @@
 
   const KEY = 'isoMetadata.contentDescriptions';
 
-  const { getValue } = getFormContext();
+  const { getValue, updateFormState } = getFormContext();
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   const valueFromData = $derived(getValue<ContentDescription[]>(KEY));
   let contentDescriptions = $state<ContentDescription[]>([]);
@@ -30,8 +31,13 @@
 
   // important that this is not a state
   let previousValueAsString: string;
+  let lastPersistedContentDescriptions = $state<ContentDescription[]>([]);
+  let hasUnsavedLocalChange = $state(false);
 
   $effect(() => {
+    if (hasUnsavedLocalChange) {
+      return;
+    }
     // this check prevents rerendering if nothing has actually changed
     const newValueAsString = JSON.stringify(valueFromData);
     if (
@@ -51,6 +57,7 @@
       };
     });
     previousValueAsString = JSON.stringify(valueFromData);
+    lastPersistedContentDescriptions = valueFromData || [];
   });
 
   let showCheckmark = $state(false);
@@ -59,17 +66,23 @@
   const codeFieldConfig = MetadataService.getFieldConfig<string>(43);
   const urlFieldConfig = MetadataService.getFieldConfig<string>(44);
 
-  const persistContentDescriptions = async (evt?: FocusEvent) => {
+  const persistContentDescriptions = async (evt?: FocusEvent, fieldIsValid = true) => {
     syncLocalContentDescriptionsState();
+    const persistableContentDescriptions = getPersistableContentDescriptions();
 
-    if (hasInvalidFields) {
+    if (!fieldIsValid) {
       return;
     }
     // Due to the SvelteKit lifecycle the blur effect gets trigger twice
     // this leads to a loss of focus on the input field. This need to be fixed.
     const focusedElement = evt?.relatedTarget as HTMLElement | null;
-    const response = await MetadataService.persistValue(KEY, contentDescriptions);
+    const response = await MetadataService.persistValue(KEY, persistableContentDescriptions);
     if (response.ok) {
+      lastPersistedContentDescriptions = persistableContentDescriptions;
+      updateFormState(KEY, contentDescriptions);
+      previousValueAsString = JSON.stringify(contentDescriptions);
+      hasUnsavedLocalChange =
+        JSON.stringify(contentDescriptions) !== JSON.stringify(persistableContentDescriptions);
       showCheckmark = true;
     }
 
@@ -78,6 +91,26 @@
       const elementToFocus = document.getElementById(focusedElement.id);
       elementToFocus?.focus();
     }, 10);
+  };
+
+  const getPersistableContentDescriptions = () => {
+    return getPersistableItems(contentDescriptions, lastPersistedContentDescriptions, [
+      {
+        key: 'code',
+        isValid: (contentDescription) =>
+          codeFieldConfig?.validator(contentDescription.code)?.valid === true
+      },
+      {
+        key: 'description',
+        isValid: (contentDescription) =>
+          descriptionFieldConfig?.validator(contentDescription.description)?.valid === true
+      },
+      {
+        key: 'url',
+        isValid: (contentDescription) =>
+          urlFieldConfig?.validator(contentDescription.url)?.valid === true
+      }
+    ]);
   };
 
   const syncLocalContentDescriptionsState = () => {
@@ -90,13 +123,8 @@
       return;
     }
 
-    formState.metadata = {
-      ...formState.metadata,
-      isoMetadata: {
-        ...formState.metadata.isoMetadata,
-        contentDescriptions
-      }
-    };
+    hasUnsavedLocalChange = true;
+    updateFormState(KEY, contentDescriptions);
   };
 
   $effect(() => {
@@ -115,7 +143,7 @@
       },
       ...contentDescriptions
     ];
-    persistContentDescriptions();
+    syncLocalContentDescriptionsState();
   };
 
   const removeItem = (id: string, evt: MouseEvent) => {
@@ -144,9 +172,9 @@
       (editingRoles ? editingRoles?.includes(highestRole) : true);
     const hasInvalidFields = contentDescriptions.some((contentDescription) => {
       const descriptionValid =
-        descriptionFieldConfig?.validator(contentDescription.description).valid ?? true;
-      const urlValid = urlFieldConfig?.validator(contentDescription.url).valid ?? true;
-      const codeValid = codeFieldConfig?.validator(contentDescription.code).valid ?? true;
+        descriptionFieldConfig?.validator(contentDescription.description)?.valid ?? true;
+      const urlValid = urlFieldConfig?.validator(contentDescription.url)?.valid ?? true;
+      const codeValid = codeFieldConfig?.validator(contentDescription.code)?.valid ?? true;
       return !descriptionValid || !urlValid || !codeValid;
     });
     return isEditingRole && hasInvalidFields;
@@ -185,7 +213,17 @@
           <TextInput
             bind:value={contentDescription.description}
             label={t('41_AdditionalInformation.description')}
-            onblur={persistContentDescriptions}
+            onchange={(evt) => {
+              contentDescription.description = (evt.target as HTMLInputElement).value;
+              syncLocalContentDescriptionsState();
+            }}
+            onblur={(evt) => {
+              contentDescription.description = (evt.target as HTMLInputElement).value;
+              persistContentDescriptions(
+                evt,
+                descriptionFieldConfig?.validator(contentDescription.description)?.valid === true
+              );
+            }}
             fieldConfig={descriptionFieldConfig}
             validationResult={descriptionFieldConfig?.validator(contentDescription.description)}
             id={`${KEY}-${index}-description`}
@@ -199,7 +237,7 @@
         <div class="inline-fields">
           <div class="subfield-wrapper code-select-field">
             <SelectInput
-              value={contentDescription.code}
+              bind:value={contentDescription.code}
               onChange={(code) => {
                 contentDescription.code = code as CI_OnLineFunctionCode;
                 persistContentDescriptions();
@@ -222,7 +260,17 @@
             <TextInput
               bind:value={contentDescription.url}
               label={t('44_AdditionalInformationUrl.label')}
-              onblur={persistContentDescriptions}
+              onchange={(evt) => {
+                contentDescription.url = (evt.target as HTMLInputElement).value;
+                syncLocalContentDescriptionsState();
+              }}
+              onblur={(evt) => {
+                contentDescription.url = (evt.target as HTMLInputElement).value;
+                persistContentDescriptions(
+                  evt,
+                  urlFieldConfig?.validator(contentDescription.url)?.valid === true
+                );
+              }}
               fieldConfig={urlFieldConfig}
               validationResult={urlFieldConfig?.validator(contentDescription.url)}
               id={`${KEY}-${index}-url`}

--- a/src/lib/components/Form/Inputs/SelectInput.svelte
+++ b/src/lib/components/Form/Inputs/SelectInput.svelte
@@ -46,6 +46,12 @@
     onChange?.(newValue);
   };
 
+  const onSelectChange = (index: number) => {
+    const option = uniqueOptions[index];
+    if (!option || option.disabled) return;
+    onSelect(option.key);
+  };
+
   const selectedDescription = $derived(
     uniqueOptions.find((item) => item.key === value)?.description
   );
@@ -62,12 +68,21 @@
 
 <fieldset class={['select-input', wrapperClass, isInvalid && 'invalid']}>
   <legend>{label}</legend>
-  <Select bind:value {disabled} menu$managed {...restProps}>
+  <Select
+    bind:value
+    {disabled}
+    menu$managed
+    {...restProps}
+    onSMUIMenuSelected={(evt) => onSelectChange(evt.detail.index)}
+  >
     {#each options as option (option.key)}
       <SafeSelectOption
-        onSMUIAction={() => {
+        onclick={() => {
           if (option.disabled) return;
           onSelect(option.key);
+        }}
+        onSMUIAction={() => {
+          if (option.disabled) return;
         }}
         value={option.key}
         disabled={option.disabled}

--- a/src/lib/components/Form/persistableItems.ts
+++ b/src/lib/components/Form/persistableItems.ts
@@ -1,0 +1,44 @@
+export type PersistableField<T> = {
+  key: keyof T;
+  isValid: (item: T) => boolean;
+};
+
+export function getPersistableItems<T extends { id: string }>(
+  items: T[],
+  previousItems: T[],
+  fields: PersistableField<T>[]
+) {
+  return items.map((item) => {
+    const previous = previousItems.find((entry) => entry.id === item.id);
+    const next: Partial<T> = { id: item.id } as Partial<T>;
+
+    fields.forEach(({ key, isValid }) => {
+      if (isValid(item)) {
+        next[key] = item[key];
+        return;
+      }
+
+      if (previous?.[key] !== undefined) {
+        next[key] = previous[key];
+      }
+    });
+
+    return next as T;
+  });
+}
+
+export async function persistItems<T extends { id: string }>(
+  items: T[],
+  previousItems: T[],
+  fields: PersistableField<T>[],
+  persist: (items: T[]) => Promise<Response>,
+  prepare: (items: T[]) => T[] = (items) => items
+) {
+  const persistableItems = prepare(getPersistableItems(items, previousItems, fields));
+  const response = await persist(persistableItems);
+
+  return {
+    response,
+    persistableItems
+  };
+}

--- a/src/lib/components/Form/service/40_ServiceForm.svelte
+++ b/src/lib/components/Form/service/40_ServiceForm.svelte
@@ -22,7 +22,6 @@
   import { logger } from 'loggisch';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
-  import { validateFeatureTypes } from './validation';
   import { ValidationService } from '$lib/services/ValidationService';
 
   const t = $derived(page.data.t);
@@ -148,17 +147,7 @@
       return fieldConfig?.validator(value as Service['shortDescription']).valid;
     }
     if (key === 'featureTypes') {
-      const fieldConfig = MetadataService.getFieldConfig<Service['featureTypes']>(56);
-      const featureTypes = value as Service['featureTypes'];
-      const hasValidFeatureTypeCollection = fieldConfig?.validator(featureTypes, {
-        ['PARENT_VALUE']: service
-      }).valid;
-      const hasInvalidFeatureTypes =
-        validateFeatureTypes(featureTypes || [], {
-          metadata,
-          HIGHEST_ROLE: highestRole
-        }).size > 0;
-      return hasValidFeatureTypeCollection && !hasInvalidFeatureTypes;
+      return true;
     }
     if (key === 'serviceType') {
       const fieldConfig = MetadataService.getFieldConfig<ServiceType>(58);

--- a/src/lib/components/Form/service/40_ServicesSection.svelte
+++ b/src/lib/components/Form/service/40_ServicesSection.svelte
@@ -3,7 +3,7 @@
   import { getFormContext } from '$lib/context/FormContext.svelte';
   import { getAccessToken } from '$lib/context/TokenContext.svelte';
   import { getHighestRole } from '$lib/util';
-  import type { Layer, Service } from '$lib/models/metadata';
+  import type { ColumnInfo, FeatureType, Layer, Service } from '$lib/models/metadata';
   import ServiceForm_40 from './40_ServiceForm.svelte';
   import Checkmark from '../Checkmark.svelte';
   import FieldHint from '../FieldHint.svelte';
@@ -13,6 +13,7 @@
   import { MetadataService } from '$lib/services/MetadataService';
   import { SvelteSet } from 'svelte/reactivity';
   import { ValidationService } from '$lib/services/ValidationService';
+  import { getPersistableItems } from '../persistableItems';
 
   const t = $derived(page.data.t);
 
@@ -101,14 +102,94 @@
   };
 
   const getPersistableServices = (serviceList: Service[]) => {
-    return serviceList.map((service) => {
-      if (isWorkspacePersistable(service, serviceList)) {
-        return service;
-      }
+    return serviceList.map((service) => getPersistableService(service, serviceList));
+  };
 
-      const lastPersisted = lastPersistedServices.find((entry) => entry.id === service.id);
-      return lastPersisted ? { ...service, workspace: lastPersisted.workspace } : service;
+  const getPersistableService = (service: Service, serviceList: Service[]) => {
+    const previous = lastPersistedServices.find((entry) => entry.id === service.id);
+    const field58 = MetadataService.getFieldConfig(58);
+    const field59 = MetadataService.getFieldConfig<string>(59);
+    const field60 = MetadataService.getFieldConfig<string>(60);
+    const field46 = MetadataService.getFieldConfig<string>(46);
+
+    const next = getPersistableItems([service], previous ? [previous] : [], [
+      {
+        key: 'serviceType',
+        isValid: (entry) => field58?.validator(entry.serviceType)?.valid === true
+      },
+      { key: 'title', isValid: (entry) => field59?.validator(entry.title)?.valid === true },
+      {
+        key: 'shortDescription',
+        isValid: (entry) => field60?.validator(entry.shortDescription)?.valid === true
+      },
+      {
+        key: 'preview',
+        isValid: (entry) =>
+          field46?.validator(entry.preview, { PARENT_VALUE: entry })?.valid === true
+      },
+      { key: 'workspace', isValid: (entry) => isWorkspacePersistable(entry, serviceList) }
+    ])[0];
+
+    next.serviceIdentification = service.serviceIdentification;
+    if (service.legendImage !== undefined) next.legendImage = service.legendImage;
+    if (service.fileIdentifier !== undefined) next.fileIdentifier = service.fileIdentifier;
+    if (service.featureTypes !== undefined) {
+      next.featureTypes = getPersistableFeatureTypes(service.featureTypes, previous?.featureTypes);
+    }
+
+    return next;
+  };
+
+  const getPersistableFeatureTypes = (
+    featureTypes: FeatureType[],
+    previousFeatureTypes: FeatureType[] = []
+  ) => {
+    const field61 = MetadataService.getFieldConfig<string>(61);
+    const field62 = MetadataService.getFieldConfig<string>(62);
+    const field69 = MetadataService.getFieldConfig<string>(69);
+
+    return getPersistableItems(featureTypes, previousFeatureTypes, [
+      {
+        key: 'title',
+        isValid: (featureType) => {
+          const context = { metadata, HIGHEST_ROLE: highestRole, PARENT_VALUE: featureType };
+          return field61?.validator(featureType.title, context)?.valid === true;
+        }
+      },
+      {
+        key: 'name',
+        isValid: (featureType) => {
+          const context = { metadata, HIGHEST_ROLE: highestRole, PARENT_VALUE: featureType };
+          return field62?.validator(featureType.name, context)?.valid === true;
+        }
+      },
+      {
+        key: 'shortDescription',
+        isValid: (featureType) => {
+          const context = { metadata, HIGHEST_ROLE: highestRole, PARENT_VALUE: featureType };
+          return field69?.validator(featureType.shortDescription, context)?.valid === true;
+        }
+      }
+    ]).map((featureType) => {
+      const localFeatureType = featureTypes.find((entry) => entry.id === featureType.id);
+      const previous = previousFeatureTypes.find((entry) => entry.id === featureType.id);
+      return {
+        ...featureType,
+        columns: getPersistableColumns(localFeatureType?.columns || [], previous?.columns || [])
+      };
     });
+  };
+
+  const getPersistableColumns = (columns: ColumnInfo[], previousColumns: ColumnInfo[] = []) => {
+    const field64 = MetadataService.getFieldConfig<string>(64);
+    const field65 = MetadataService.getFieldConfig<string>(65);
+    const field66 = MetadataService.getFieldConfig<ColumnInfo['type']>(66);
+
+    return getPersistableItems(columns, previousColumns, [
+      { key: 'name', isValid: (column) => field64?.validator(column.name)?.valid === true },
+      { key: 'alias', isValid: (column) => field65?.validator(column.alias)?.valid === true },
+      { key: 'type', isValid: (column) => field66?.validator(column.type)?.valid === true }
+    ]);
   };
 
   const persistServices = async (id: string) => {
@@ -133,7 +214,6 @@
       }
     ];
     activeTab = id;
-    persistServices(id);
   }
 
   function removeService(id: string, evt: MouseEvent) {

--- a/src/lib/components/Form/service/48_LayersForm.svelte
+++ b/src/lib/components/Form/service/48_LayersForm.svelte
@@ -18,6 +18,8 @@
   import { page } from '$app/state';
   import { validateLayers } from './validation';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { persistItems } from '../persistableItems';
+  import type { FullFieldConfig } from '../FieldsConfig';
   const t = $derived(page.data.t);
 
   type Tab = {
@@ -53,6 +55,14 @@
   let activeLayer = $derived(layers.find((layer) => layer.id === activeTabId));
 
   const fieldConfig = MetadataService.getFieldConfig(48);
+  const titleFieldConfig = MetadataService.getFieldConfig<string>(49);
+  const nameFieldConfig = MetadataService.getFieldConfig<string>(50);
+  const styleNameFieldConfig = MetadataService.getFieldConfig<string>(51);
+  const styleTitleFieldConfig = MetadataService.getFieldConfig<string>(52);
+  const legendImageFieldConfig = MetadataService.getFieldConfig<string>(53);
+  const descriptionFieldConfig = MetadataService.getFieldConfig<string>(54);
+  const datasourceFieldConfig = MetadataService.getFieldConfig<string>(55);
+  const secondaryDatasourceFieldConfig = MetadataService.getFieldConfig<string>(68);
   const validationResult = $derived(
     fieldConfig?.validator(layers, {
       PARENT_VALUE: service
@@ -61,11 +71,15 @@
 
   const invalidTabIds = $derived(validateLayers(layers, { metadata, HIGHEST_ROLE: highestRole }));
   const isInvalid = $derived(layers.length === 0 || invalidTabIds.size > 0);
+  let lastPersistedLayers = $state<Layer[]>([]);
+  let lastServiceId: string | undefined;
 
   $effect(() => {
     // if the serviceId changes set activeTabIndex to undefined
-    if (serviceId) {
+    if (serviceId && serviceId !== lastServiceId) {
       activeTabId = undefined;
+      lastPersistedLayers = initialLayers || [];
+      lastServiceId = serviceId;
     }
   });
 
@@ -82,7 +96,6 @@
     ];
     syncLocalLayers(layers);
     activeTabId = id;
-    onChange(layers);
   }
 
   function removeLayer(layerId: string, evt: MouseEvent) {
@@ -96,7 +109,7 @@
         if (activeTabId === layerId) {
           activeTabId = layers.length > 0 ? layers[layers.length - 1]?.id : undefined;
         }
-        onChange(layers);
+        persistLayers(layers);
         activeTabId = layers.length > 0 ? activeTabId : undefined;
         if (activeTabId && !layers.find((layer) => layer.id === activeTabId)) {
           activeTabId = layers[0]?.id;
@@ -120,7 +133,63 @@
       return layer;
     });
     syncLocalLayers(layers);
-    return onChange(layers, persist);
+    return persist === false ? onChange(layers, false) : persistLayers(layers);
+  }
+
+  async function persistLayers(nextLayers: Layer[]) {
+    const { response, persistableItems } = await persistItems(
+      nextLayers,
+      lastPersistedLayers,
+      [
+        {
+          key: 'title',
+          isValid: (layer) => isLayerFieldValid(titleFieldConfig, layer.title, layer)
+        },
+        { key: 'name', isValid: (layer) => isLayerFieldValid(nameFieldConfig, layer.name, layer) },
+        {
+          key: 'styleName',
+          isValid: (layer) => isLayerFieldValid(styleNameFieldConfig, layer.styleName, layer)
+        },
+        {
+          key: 'styleTitle',
+          isValid: (layer) => isLayerFieldValid(styleTitleFieldConfig, layer.styleTitle, layer)
+        },
+        {
+          key: 'legendImage',
+          isValid: (layer) => isLayerFieldValid(legendImageFieldConfig, layer.legendImage, layer)
+        },
+        {
+          key: 'shortDescription',
+          isValid: (layer) =>
+            isLayerFieldValid(descriptionFieldConfig, layer.shortDescription, layer)
+        },
+        {
+          key: 'datasource',
+          isValid: (layer) => isLayerFieldValid(datasourceFieldConfig, layer.datasource, layer)
+        },
+        {
+          key: 'secondaryDatasource',
+          isValid: (layer) =>
+            isLayerFieldValid(secondaryDatasourceFieldConfig, layer.secondaryDatasource, layer)
+        }
+      ],
+      onChange
+    );
+    if (response.ok) {
+      lastPersistedLayers = persistableItems;
+    }
+    return response;
+  }
+
+  function isLayerFieldValid<T>(
+    fieldConfig: FullFieldConfig<T>,
+    value: T | undefined,
+    layer: Layer
+  ) {
+    return (
+      fieldConfig?.validator(value, { metadata, HIGHEST_ROLE: highestRole, PARENT_VALUE: layer })
+        .valid === true
+    );
   }
 
   function syncLocalLayers(nextLayers: Layer[]) {

--- a/src/lib/components/Form/service/56_FeatureTypeForm.svelte
+++ b/src/lib/components/Form/service/56_FeatureTypeForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import IconButton from '@smui/icon-button';
   import ColumnsForm_63 from './63_ColumnsForm.svelte';
-  import type { FeatureType, Service } from '$lib/models/metadata';
+  import type { ColumnInfo, FeatureType, Service } from '$lib/models/metadata';
   import FeatureTypeTitle_61 from './Field/61_FeatureTypeTitle.svelte';
   import FeatureTypeName_62 from './Field/62_FeatureTypeName.svelte';
   import FeatureTypeDescription_69 from './Field/69_FeatureTypeDescription.svelte';
@@ -14,6 +14,8 @@
   import { page } from '$app/state';
   import { validateFeatureTypes } from './validation';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { getPersistableItems, persistItems } from '../persistableItems';
+  import type { FullFieldConfig } from '../FieldsConfig';
   const t = $derived(page.data.t);
 
   type Tab = {
@@ -49,6 +51,9 @@
   let activeFeatureType = $derived(featureTypes.find((ft) => ft.id === activeTabId));
 
   const fieldConfig = MetadataService.getFieldConfig(56);
+  const titleFieldConfig = MetadataService.getFieldConfig<string>(61);
+  const nameFieldConfig = MetadataService.getFieldConfig<string>(62);
+  const descriptionFieldConfig = MetadataService.getFieldConfig<string>(69);
   const validationResult = $derived(
     fieldConfig?.validator(featureTypes, { PARENT_VALUE: service })
   );
@@ -57,11 +62,15 @@
     validateFeatureTypes(featureTypes, { metadata, HIGHEST_ROLE: highestRole })
   );
   const isInvalid = $derived(featureTypes.length === 0 || invalidTabIds.size > 0);
+  let lastPersistedFeatureTypes = $state<FeatureType[]>([]);
+  let lastServiceId: string | undefined;
 
   $effect(() => {
     // if the serviceId changes set activeTabIndex to undefined
-    if (serviceId) {
+    if (serviceId && serviceId !== lastServiceId) {
       activeTabId = undefined;
+      lastPersistedFeatureTypes = initialFeatureTypes || [];
+      lastServiceId = serviceId;
     }
   });
 
@@ -79,7 +88,6 @@
     ];
     syncLocalFeatureTypes(featureTypes);
     activeTabId = id;
-    onChange(featureTypes);
   }
 
   function removeFeatureType(id: string, evt: MouseEvent) {
@@ -93,7 +101,7 @@
         if (activeTabId === id) {
           activeTabId = featureTypes.length > 1 ? featureTypes[0].id : undefined;
         }
-        onChange(featureTypes);
+        persistFeatureTypes(featureTypes);
         activeTabId = featureTypes.length > 0 ? activeTabId : undefined;
         if (activeTabId && !featureTypes.find((ft) => ft.id === activeTabId)) {
           activeTabId = featureTypes[0]?.id;
@@ -117,7 +125,87 @@
       return featureType;
     });
     syncLocalFeatureTypes(featureTypes);
-    return onChange(featureTypes, persist);
+    return persist === false ? onChange(featureTypes, false) : persistFeatureTypes(featureTypes);
+  }
+
+  async function persistFeatureTypes(nextFeatureTypes: FeatureType[]) {
+    const { response, persistableItems } = await persistItems(
+      nextFeatureTypes,
+      lastPersistedFeatureTypes,
+      [
+        {
+          key: 'title',
+          isValid: (featureType) =>
+            isFeatureTypeFieldValid(titleFieldConfig, featureType.title, featureType)
+        },
+        {
+          key: 'name',
+          isValid: (featureType) =>
+            isFeatureTypeFieldValid(nameFieldConfig, featureType.name, featureType)
+        },
+        {
+          key: 'shortDescription',
+          isValid: (featureType) =>
+            isFeatureTypeFieldValid(
+              descriptionFieldConfig,
+              featureType.shortDescription,
+              featureType
+            )
+        }
+      ],
+      onChange,
+      (featureTypes) => addPersistableColumns(featureTypes, nextFeatureTypes)
+    );
+    if (response.ok) {
+      lastPersistedFeatureTypes = persistableItems;
+    }
+    return response;
+  }
+
+  function addPersistableColumns(featureTypes: FeatureType[], nextFeatureTypes: FeatureType[]) {
+    return featureTypes.map((featureType) => {
+      const localFeatureType = nextFeatureTypes.find((entry) => entry.id === featureType.id);
+      const previous = lastPersistedFeatureTypes.find((entry) => entry.id === featureType.id);
+      return {
+        ...featureType,
+        columns: getPersistableColumns(localFeatureType?.columns || [], previous?.columns || [])
+      };
+    });
+  }
+
+  function isFeatureTypeFieldValid<T>(
+    fieldConfig: FullFieldConfig<T>,
+    value: T | undefined,
+    featureType: FeatureType
+  ) {
+    return (
+      fieldConfig?.validator(value, {
+        metadata,
+        HIGHEST_ROLE: highestRole,
+        PARENT_VALUE: featureType
+      })?.valid === true
+    );
+  }
+
+  function getPersistableColumns(columns: ColumnInfo[], previousColumns: ColumnInfo[]) {
+    const nameFieldConfig = MetadataService.getFieldConfig<string>(64);
+    const aliasFieldConfig = MetadataService.getFieldConfig<string>(65);
+    const typeFieldConfig = MetadataService.getFieldConfig<ColumnInfo['type']>(66);
+
+    return getPersistableItems(columns, previousColumns, [
+      {
+        key: 'name',
+        isValid: (column) => nameFieldConfig?.validator(column.name)?.valid === true
+      },
+      {
+        key: 'alias',
+        isValid: (column) => aliasFieldConfig?.validator(column.alias)?.valid === true
+      },
+      {
+        key: 'type',
+        isValid: (column) => typeFieldConfig?.validator(column.type)?.valid === true
+      }
+    ]);
   }
 
   function syncLocalFeatureTypes(nextFeatureTypes: FeatureType[]) {

--- a/src/lib/components/Form/service/63_ColumnsForm.svelte
+++ b/src/lib/components/Form/service/63_ColumnsForm.svelte
@@ -13,6 +13,7 @@
   import { page } from '$app/state';
   import { validateColumns } from './validation';
   import { MetadataService } from '$lib/services/MetadataService';
+  import { persistItems } from '../persistableItems';
   const t = $derived(page.data.t);
 
   type Tab = {
@@ -48,15 +49,22 @@
   let activeColumn = $derived(columns.find((column) => column.id === activeTabId));
 
   const fieldConfig = MetadataService.getFieldConfig(63);
+  const nameFieldConfig = MetadataService.getFieldConfig<string>(64);
+  const aliasFieldConfig = MetadataService.getFieldConfig<string>(65);
+  const typeFieldConfig = MetadataService.getFieldConfig<ColumnInfo['type']>(66);
   const validationResult = $derived(fieldConfig?.validator(columns));
 
   const invalidTabIds = $derived(validateColumns(columns, { metadata, HIGHEST_ROLE: highestRole }));
   const isInvalid = $derived(columns.length === 0 || invalidTabIds.size > 0);
+  let lastPersistedColumns = $state<ColumnInfo[]>([]);
+  let lastFeatureTypeName: string | undefined;
 
   $effect(() => {
     // if the featureType changes set activeTabIndex to undefined
-    if (featureTypeName) {
+    if (featureTypeName && featureTypeName !== lastFeatureTypeName) {
       activeTabId = undefined;
+      lastPersistedColumns = initialColumns || [];
+      lastFeatureTypeName = featureTypeName;
     }
   });
 
@@ -71,7 +79,6 @@
       }
     ];
     activeTabId = id;
-    onChange(columns);
   }
 
   function removeColumn(id: string, evt: MouseEvent) {
@@ -84,7 +91,7 @@
         if (activeTabId === id) {
           activeTabId = columns.length > 0 ? columns[0].id : undefined;
         }
-        onChange(columns);
+        persistColumns(columns);
         activeTabId = columns.length > 0 ? activeTabId : undefined;
         if (activeTabId && !columns.find((column) => column.id === activeTabId)) {
           activeTabId = columns[0]?.id;
@@ -107,7 +114,33 @@
       }
       return column;
     });
-    return onChange(columns, persist);
+    return persist === false ? onChange(columns, false) : persistColumns(columns);
+  }
+
+  async function persistColumns(nextColumns: ColumnInfo[]) {
+    const { response, persistableItems } = await persistItems(
+      nextColumns,
+      lastPersistedColumns,
+      [
+        {
+          key: 'name',
+          isValid: (column) => nameFieldConfig?.validator(column.name)?.valid === true
+        },
+        {
+          key: 'alias',
+          isValid: (column) => aliasFieldConfig?.validator(column.alias)?.valid === true
+        },
+        {
+          key: 'type',
+          isValid: (column) => typeFieldConfig?.validator(column.type)?.valid === true
+        }
+      ],
+      onChange
+    );
+    if (response.ok) {
+      lastPersistedColumns = persistableItems;
+    }
+    return response;
   }
 </script>
 

--- a/src/lib/components/Form/service/Field/46_ServicePreview.svelte
+++ b/src/lib/components/Form/service/Field/46_ServicePreview.svelte
@@ -58,11 +58,11 @@
     onchange={(e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
       localValue = newValue;
-      void onChange(newValue, false);
     }}
     onblur={async (e: Event) => {
       const newValue = (e.target as HTMLInputElement).value;
-      const response = await onChange(newValue);
+      if (fieldConfig?.validator(newValue, { ['PARENT_VALUE']: service }).valid === false) return;
+      const response = await onChange(newValue, true);
       if (response.ok) {
         showCheckmark = true;
       }

--- a/src/lib/context/FormContext.svelte.ts
+++ b/src/lib/context/FormContext.svelte.ts
@@ -2,6 +2,7 @@ import { getContext, setContext } from 'svelte';
 import type { FieldKey } from '$lib/models/form';
 import { type MetadataCollection } from '$lib/models/metadata';
 import { MetadataService } from '$lib/services/MetadataService';
+import { logger } from 'loggisch';
 
 export type FormState = {
   metadata?: MetadataCollection;
@@ -31,6 +32,55 @@ function toggleActiveHelp(key: FieldKey, formState: FormState) {
   }
 }
 
+function setValueAtPath(
+  target: Record<string, unknown>,
+  [key, ...rest]: string[],
+  value: unknown
+): Record<string, unknown> {
+  if (!key) {
+    return target;
+  }
+
+  if (rest.length === 0) {
+    return {
+      ...target,
+      [key]: value
+    };
+  }
+
+  const child = target[key];
+  const childObject =
+    child && typeof child === 'object' && !Array.isArray(child)
+      ? (child as Record<string, unknown>)
+      : {};
+
+  return {
+    ...target,
+    [key]: setValueAtPath(childObject, rest, value)
+  };
+}
+
+function updateFormStateValue(formState: FormState, key: string, value: unknown) {
+  if (!formState.metadata) {
+    logger.error(`updateFormState: metadata is missing for ${key}`);
+    return false;
+  }
+
+  const path = key.replace(/\[(\d+)\]/g, '.$1').split('.');
+  const rootKey = path[0];
+  if (!rootKey || !formState.metadata[rootKey as keyof MetadataCollection]) {
+    logger.error(`updateFormState: ${rootKey || key} is missing for ${key}`);
+    return false;
+  }
+
+  formState.metadata = setValueAtPath(
+    formState.metadata as unknown as Record<string, unknown>,
+    path,
+    value
+  ) as MetadataCollection;
+  return true;
+}
+
 export function getFormContext() {
   const formState = getContext<FormState>(FORMSTATE_CONTEXT);
   return {
@@ -39,6 +89,7 @@ export function getFormContext() {
       MetadataService.getValue<T>(key, metadata || formState.metadata!),
     getAllValues: <T>(key: string, metadata?: MetadataCollection) =>
       MetadataService.getAllValues<T>(key, metadata || formState.metadata),
+    updateFormState: (key: string, value: unknown) => updateFormStateValue(formState, key, value),
     clearActiveHelp: () => clearActiveHelp(formState),
     toggleActiveHelp: (key: FieldKey) => toggleActiveHelp(key, formState)
   };

--- a/src/lib/services/MetadataUpdateService.ts
+++ b/src/lib/services/MetadataUpdateService.ts
@@ -278,6 +278,11 @@ export class MetadataUpdateService {
       'id' in earlierValue[0] &&
       'id' in laterValue[0]
     ) {
+      const earlierIds = new Set(earlierValue.map((item) => item.id));
+      const laterIds = new Set(laterValue.map((item) => item.id));
+      const hasSameItems =
+        earlierIds.size === laterIds.size && [...earlierIds].every((id) => laterIds.has(id));
+
       // Build map from later array (base structure)
       const itemMap = new Map<string, Record<string, unknown>>();
       for (const item of laterValue) {
@@ -292,11 +297,17 @@ export class MetadataUpdateService {
           const laterItem = itemMap.get(id)!;
           itemMap.set(
             id,
-            MetadataUpdateService.deepMergeObjects(
-              earlierItem as Record<string, unknown>,
-              laterItem,
-              visited
-            )
+            hasSameItems
+              ? MetadataUpdateService.deepMergeObjects(
+                  laterItem,
+                  earlierItem as Record<string, unknown>,
+                  visited
+                )
+              : MetadataUpdateService.deepMergeObjects(
+                  earlierItem as Record<string, unknown>,
+                  laterItem,
+                  visited
+                )
           );
         }
         // If ID doesn't exist in later array, it was deleted - don't add it back


### PR DESCRIPTION
See also [#29500](https://redmine.intranet.terrestris.de/issues/29500).

This PR is a follow-up to PR #297 (**must be merged first**).

PR #297 introduced the fundamental changes to the form persistence logic from `v6.1.x` branch: required fields are now only persisted once their current value is valid. This follow-up applies that behavior to form fields that are organized as fieldsets.

Previously, fieldsets were persisted as a whole. That meant changes inside a fieldset were only saved once all fields in that fieldset were valid.

With this PR, valid individual fields inside fieldsets can now be persisted immediately, without waiting for the complete fieldset to become valid.

This change affects the following fieldsets:

- Contacts
- Validity
- Spatial extent
- Lineage
- Additional information
- Services
- Map layers
- FeatureTypes
- Attributes

The persistence logic for these fieldsets was adjusted so that each subfield is evaluated individually before saving.

When a field inside a fieldset contains a valid value, that value can now be included in the next persist request. Invalid or incomplete sibling fields are not persisted with their invalid value. Instead, the last successfully persisted value for those fields is kept. For this purpose, a new helper (`persistableItems.ts`) centralizes the logic for saving fieldsets. It compares the current local values with the last persisted values and builds a persistable version of the data. 

