### PR TITLE
Increase dataset abstract length (#29835)

### DIFF
--- a/src/lib/components/Form/Field/02_DescriptionField.svelte
+++ b/src/lib/components/Form/Field/02_DescriptionField.svelte
@@ -61,7 +61,7 @@
 <div class="description-field">
   <TextAreaInput
     bind:value
-    maxlength={500}
+    maxlength={1250}
     onchange={() => {
       hasUnsavedLocalChange = true;
     }}

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -6,7 +6,7 @@
   },
   "02_DescriptionField": {
     "label": "Kurzbeschreibung des Datenbestandes",
-    "explanation": "Beschreiben Sie Ihren Datenbestand kurz und prägnant in 500 Zeichen. Für ausführlichere Informationen nutzen Sie die inhaltliche Beschreibung."
+    "explanation": "Beschreiben Sie Ihren Datenbestand kurz und prägnant in 1250 Zeichen. Für ausführlichere Informationen nutzen Sie die inhaltliche Beschreibung."
   },
   "04_PrivacyField": {
     "label": "Datenschutz-Einstellungen",

--- a/tests/e2e/form/Basedata.spec.ts
+++ b/tests/e2e/form/Basedata.spec.ts
@@ -52,7 +52,7 @@ test.describe('Metadata form - Basedata section', () => {
       value: 'Test description',
       checkForHelp: true,
       checkForCopy: true,
-      maxLength: 500,
+      maxLength: 1250,
       required: true,
       progressBar: {
         element: progressBar

--- a/tests/integration/Basedata.integration.ts
+++ b/tests/integration/Basedata.integration.ts
@@ -66,7 +66,7 @@ export async function testBasedata(role: string) {
           fieldType: 'textarea',
           fieldInput: 'New Description text...',
           requiredMessage: 'Bitte geben Sie eine Beschreibung an.',
-          maxLength: 500,
+          maxLength: 1250,
           help: true,
           testProgress: {
             section: 'basedata',


### PR DESCRIPTION
See also [#29835](https://redmine.intranet.terrestris.de/issues/29835).

This PR increases the dataset abstract limit from 500 to 1250 characters.