### PR TITLE
Tighten service ID validation (#29832)

### DIFF
--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -748,12 +748,16 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
       if (!required) {
         return { valid: true };
       }
-      const valid = !!(isDefined(workspace) && /^[a-zA-Z0-9_]+$/.test(workspace));
+      const valid = !!(
+        isDefined(workspace) &&
+        workspace.length <= 100 &&
+        /^[a-z0-9_]+$/.test(workspace)
+      );
       if (!valid) {
         return {
           valid: false,
           helpText:
-            'Bitte geben Sie einen gültigen Workspace an. Nur Buchstaben, Zahlen und Unterstriche sind erlaubt.'
+            'Bitte geben Sie einen gültigen Workspace an. Nur Kleinbuchstaben, Zahlen und Unterstriche sind erlaubt.'
         };
       }
       const service = extraParams?.['PARENT_VALUE'] as Service;

--- a/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
+++ b/src/lib/components/Form/service/Field/45_ServiceWorkspace.svelte
@@ -64,6 +64,7 @@
       value={localValue}
       {fieldConfig}
       {validationResult}
+      maxlength={100}
       onchange={(e: Event) => {
         const newValue = (e.target as HTMLInputElement).value;
         localValue = newValue;

--- a/tests/e2e/form/Services.spec.ts
+++ b/tests/e2e/form/Services.spec.ts
@@ -73,7 +73,8 @@ test.describe('Metadata form - Services section', () => {
       label: 'Dienst-ID',
       value: opts.serviceId,
       checkForHelp: true,
-      checkForCopy: true
+      checkForCopy: true,
+      maxLength: 100
     });
 
     await testFormField(page, '.service-preview-field', {
@@ -99,7 +100,7 @@ test.describe('Metadata form - Services section', () => {
       serviceType: 'ATOM',
       serviceTitle: 'Test ATOM Service Title',
       serviceDescription: 'Test ATOM Service Description',
-      serviceId: 'TestATOMIdentifier',
+      serviceId: 'test_atom_identifier',
       previewUrl: 'https://example.com/atom-preview.png'
     });
 
@@ -125,7 +126,7 @@ test.describe('Metadata form - Services section', () => {
       serviceType: 'WMS',
       serviceTitle: 'Test WMS Service Title',
       serviceDescription: 'Test WMS Service Description',
-      serviceId: 'TestWMSIdentifier',
+      serviceId: 'test_wms_identifier',
       previewUrl: 'https://example.com/wms-preview.png'
     });
 
@@ -259,7 +260,7 @@ test.describe('Metadata form - Services section', () => {
       serviceType: 'WFS',
       serviceTitle: 'Test WFS Service Title',
       serviceDescription: 'Test WFS Service Description',
-      serviceId: 'TestWFSIdentifier',
+      serviceId: 'test_wfs_identifier',
       previewUrl: 'https://example.com/wfs-preview.png'
     });
 

--- a/tests/helpers/TestFieldHelpers.ts
+++ b/tests/helpers/TestFieldHelpers.ts
@@ -849,11 +849,22 @@ async function testCollectionInput(options: TestFieldOptions): Promise<void> {
 }
 
 async function testServiceInput(fieldKey: string, options: TestFieldOptions): Promise<void> {
-  const { fieldset, fieldInput, requiredMessage, expectPersist = true } = options;
+  const { fieldset, fieldInput, requiredMessage, maxLength, expectPersist = true } = options;
 
   const input = await within(fieldset!).findByRole('textbox');
 
+  if (maxLength) {
+    expect(input).toHaveAttribute('maxlength', maxLength.toString());
+    expect(within(fieldset!).getByText(new RegExp(`/ ${maxLength}`))).toBeInTheDocument();
+  }
+
   await userEvent.click(input);
+  await tick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  const previousCallCount = fetchMock.mock.calls.length;
+
+  await userEvent.clear(input);
   await tick();
   await new Promise((r) => setTimeout(r, 0));
 
@@ -862,12 +873,6 @@ async function testServiceInput(fieldKey: string, options: TestFieldOptions): Pr
       expect(screen.queryByText(requiredMessage)).toBeVisible();
     });
   }
-
-  const previousCallCount = fetchMock.mock.calls.length;
-
-  await userEvent.clear(input);
-  await tick();
-  await new Promise((r) => setTimeout(r, 0));
 
   await userEvent.type(input, fieldInput as string);
   await tick();
@@ -911,6 +916,12 @@ async function testServiceInput(fieldKey: string, options: TestFieldOptions): Pr
   await waitFor(() => {
     expect(input).toHaveValue(fieldInput as string);
   });
+
+  if (maxLength) {
+    expect(
+      within(fieldset!).getByText(new RegExp(`${(fieldInput as string).length} / ${maxLength}`))
+    ).toBeInTheDocument();
+  }
 
   await waitFor(() => {
     expect(document.querySelector('.running')).toBeVisible();

--- a/tests/integration/Services.integration.ts
+++ b/tests/integration/Services.integration.ts
@@ -181,9 +181,10 @@ export async function testServices(role: string) {
             await testField('isoMetadata.services.workspace', {
               fieldset: fieldset,
               fieldType: 'service',
-              fieldInput: 'NewValidServiceWorkspace',
+              fieldInput: 'new_valid_service_workspace',
+              maxLength: 100,
               requiredMessage:
-                'Bitte geben Sie einen gültigen Workspace an. Nur Buchstaben, Zahlen und Unterstriche sind erlaubt.',
+                'Bitte geben Sie einen gültigen Workspace an. Nur Kleinbuchstaben, Zahlen und Unterstriche sind erlaubt.',
               help: true,
               testProgress: {
                 section: 'services',


### PR DESCRIPTION
See also [#29832](https://redmine.intranet.terrestris.de/issues/29832).

This PR limits service IDs to 100 characters and allows only lowercase letters, numbers, and underscores. It also updates the validation message and E2E test data.