### PR TITLE
Unify technical name validation (#29224)

### DIFF
--- a/src/lib/components/Form/FieldsConfig.ts
+++ b/src/lib/components/Form/FieldsConfig.ts
@@ -107,6 +107,8 @@ const isValidEmail = (val: string) => {
   return emailRegex.test(val);
 };
 
+const isValidTechnicalName = (val: string) => /^[a-z_-][a-z0-9_-]{0,99}$/.test(val);
+
 const formatDate = (date: Date | string): string => {
   if (typeof date === 'string') {
     date = new Date(date);
@@ -864,6 +866,13 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
           helpText: 'Bitte geben Sie einen Namen für die Kartenebene an.'
         };
       }
+      if (isDefined(name) && !isValidTechnicalName(name)) {
+        return {
+          valid: false,
+          helpText:
+            'Bitte geben Sie einen gültigen Namen ein. Erlaubt sind Kleinbuchstaben, Zahlen, Unterstriche und Bindestriche. Das erste Zeichen darf keine Zahl sein.'
+        };
+      }
       return { valid: true };
     },
     section: 'services',
@@ -882,6 +891,13 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
         return {
           valid: false,
           helpText: 'Bitte geben Sie einen Style-Namen für die Kartenebene an.'
+        };
+      }
+      if (isDefined(styleName) && !isValidTechnicalName(styleName)) {
+        return {
+          valid: false,
+          helpText:
+            'Bitte geben Sie einen gültigen Namen ein. Erlaubt sind Kleinbuchstaben, Zahlen, Unterstriche und Bindestriche. Das erste Zeichen darf keine Zahl sein.'
         };
       }
       return { valid: true };
@@ -1021,11 +1037,11 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
             helpText: 'Bitte geben Sie einen Namen für den FeatureType an.'
           };
         }
-        if (isDefined(name) && !/^[a-zA-Z0-9_]+$/.test(name)) {
+        if (isDefined(name) && !isValidTechnicalName(name)) {
           return {
             valid: false,
             helpText:
-              'Bitte geben Sie einen gültigen Namen für den FeatureType an. Nur Buchstaben, Zahlen und Unterstriche sind erlaubt.'
+              'Bitte geben Sie einen gültigen Namen ein. Erlaubt sind Kleinbuchstaben, Zahlen, Unterstriche und Bindestriche. Das erste Zeichen darf keine Zahl sein.'
           };
         }
       }
@@ -1048,7 +1064,22 @@ export const FieldConfigs: FullFieldConfig<any>[] = [
     profileId: 64,
     key: 'isoMetadata.services.featureTypes.columns.name',
     collectionKey: 'isoMetadata.services.featureTypes.columns',
-    validator: requiredValidator('Bitte geben Sie einen Namen für die Spalte an.'),
+    validator: (name: string | undefined) => {
+      if (!isDefined(name)) {
+        return {
+          valid: false,
+          helpText: 'Bitte geben Sie einen Namen für die Spalte an.'
+        };
+      }
+      if (!isValidTechnicalName(name)) {
+        return {
+          valid: false,
+          helpText:
+            'Bitte geben Sie einen gültigen Namen ein. Erlaubt sind Kleinbuchstaben, Zahlen, Unterstriche und Bindestriche. Das erste Zeichen darf keine Zahl sein.'
+        };
+      }
+      return { valid: true };
+    },
     section: 'services',
     required: true
   },

--- a/src/lib/components/Form/service/Field/64_AttributeName.svelte
+++ b/src/lib/components/Form/service/Field/64_AttributeName.svelte
@@ -25,6 +25,7 @@
     label={t('64_AttributeName.label')}
     explanation={t('64_AttributeName.explanation')}
     value={localValue}
+    maxlength={100}
     {fieldConfig}
     {validationResult}
     onchange={(e: Event) => {

--- a/tests/FieldsConfig.spec.ts
+++ b/tests/FieldsConfig.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { FieldConfigs } from '$lib/components/Form/FieldsConfig';
+import type { ValidationContext } from '$lib/services/ValidationService';
+
+const featureType = { id: 'feature-type' };
+const contexts: Record<number, ValidationContext | undefined> = {
+  50: { HIGHEST_ROLE: 'MdeEditor' },
+  51: { HIGHEST_ROLE: 'MdeEditor' },
+  62: {
+    HIGHEST_ROLE: 'MdeEditor',
+    PARENT_VALUE: featureType,
+    'isoMetadata.services': [
+      {
+        serviceType: 'WFS',
+        featureTypes: [featureType]
+      }
+    ]
+  },
+  64: undefined
+};
+
+describe.each([50, 51, 62, 64])('field %i technical name validation', (profileId) => {
+  const fieldConfig = FieldConfigs.find((config) => config.profileId === profileId);
+  const context = contexts[profileId as keyof typeof contexts];
+
+  test.each(['name', '_name', '-name', 'name-1_2', 'a'.repeat(100)])('accepts %s', (value) => {
+    expect(fieldConfig?.validator(value, context)).toEqual({ valid: true });
+  });
+
+  test.each(['1name', 'Name', 'name.test', 'name test', 'a'.repeat(101)])('rejects %s', (value) => {
+    expect(fieldConfig?.validator(value, context).valid).toBe(false);
+  });
+});

--- a/tests/FormContext.spec.ts
+++ b/tests/FormContext.spec.ts
@@ -40,7 +40,7 @@ describe('FormContext', () => {
           'isoMetadata.services[2].featureTypes[0].columns[0].name',
           metadata1
         )
-      ).toBe('Mein Attribut');
+      ).toBe('mein_attribut');
     });
 
     test('should return undefined for non-existent paths', () => {
@@ -55,7 +55,7 @@ describe('FormContext', () => {
         'isoMetadata.services.featureTypes.columns.name',
         metadata1
       );
-      expect(names).toEqual(['Mein Attribut', 'Mein zweites Attribut ']);
+      expect(names).toEqual(['mein_attribut', 'mein_zweites_attribut']);
     });
 
     test('should collect all service titles', () => {

--- a/tests/MetadataService.spec.ts
+++ b/tests/MetadataService.spec.ts
@@ -35,7 +35,7 @@ describe('MetadataService', () => {
         'isoMetadata.services[2].featureTypes[0].columns[0].name',
         metadata1
       );
-      expect(result).toBe('Mein Attribut');
+      expect(result).toBe('mein_attribut');
     });
 
     test('should return undefined if path does not exist', () => {
@@ -86,7 +86,7 @@ describe('MetadataService', () => {
         'isoMetadata.services.featureTypes.columns.name',
         metadata1
       );
-      expect(result).toEqual(['Mein Attribut', 'Mein zweites Attribut ']);
+      expect(result).toEqual(['mein_attribut', 'mein_zweites_attribut']);
     });
 
     test('should return empty array for metadata2 services (empty collection)', () => {

--- a/tests/fixtures/metadata1.ts
+++ b/tests/fixtures/metadata1.ts
@@ -82,13 +82,13 @@ export default {
             columns: [
               {
                 id: 'col-1',
-                name: 'Mein Attribut',
+                name: 'mein_attribut',
                 alias: 'Der andere Name meines Attributs',
                 type: 'Date'
               },
               {
                 id: 'col-2',
-                name: 'Mein zweites Attribut ',
+                name: 'mein_zweites_attribut',
                 alias: 'Attribut 2',
                 type: 'Double'
               }

--- a/tests/integration/Layers.integration.ts
+++ b/tests/integration/Layers.integration.ts
@@ -74,7 +74,7 @@ export async function testLayersForm(role: string) {
           await testField('clientMetadata.layers', {
             fieldset: fieldset,
             fieldType: 'service',
-            fieldInput: 'New Layer Name',
+            fieldInput: 'new-layer_name',
             help: true,
             testProgress: {
               section: 'services',
@@ -107,7 +107,7 @@ export async function testLayersForm(role: string) {
           await testField('clientMetadata.layers', {
             fieldset: fieldset as HTMLElement,
             fieldType: 'service',
-            fieldInput: 'New Layer Style Name',
+            fieldInput: 'new-layer-style_name',
             help: true,
             testProgress: {
               section: 'services',

--- a/tests/integration/ReadOnly.integration.spec.ts
+++ b/tests/integration/ReadOnly.integration.spec.ts
@@ -838,7 +838,7 @@ describe('MetadataDisplay - Integration test', () => {
       );
       testFieldVisibility(role, '62_FeatureTypeName.label', 'my_feature_type', '#services', true);
       testFieldVisibility(role, '63_ColumnsForm.label', undefined, '#services', true);
-      testFieldVisibility(role, '64_AttributeName.label', 'Mein Attribut', '#services', true);
+      testFieldVisibility(role, '64_AttributeName.label', 'mein_attribut', '#services', true);
       testFieldVisibility(
         role,
         '65_AttributeAlias.label',

--- a/tests/integration/Services.integration.ts
+++ b/tests/integration/Services.integration.ts
@@ -302,7 +302,7 @@ export async function testServices(role: string) {
               await testField('isoMetadata.services.featureTypes.name', {
                 fieldset: fieldset,
                 fieldType: 'text',
-                fieldInput: 'New FeatureType Name',
+                fieldInput: 'new-featuretype_name',
                 expectPersist: false,
                 help: true,
                 testProgress: {
@@ -377,7 +377,7 @@ export async function testServices(role: string) {
               await testField('isoMetadata.services.featureTypes.columns.name', {
                 fieldset: fieldset,
                 fieldType: 'text',
-                fieldInput: 'New FeatureType Name',
+                fieldInput: 'new-attribute_name',
                 expectPersist: false,
                 help: true,
                 testProgress: {


### PR DESCRIPTION
See also [#29224](https://redmine.intranet.terrestris.de/issues/29224).

This PR
- unifies validation for layer, style, feature type, and attribute names
- restricts values to 100 lowercase characters, numbers, underscores, and hyphens
- prevents names from starting with a number
- adds validation and integration test coverage