### PR TITLE
Disable date field autocomplete

### DIFF
--- a/src/lib/components/Form/Inputs/DateInput.svelte
+++ b/src/lib/components/Form/Inputs/DateInput.svelte
@@ -77,6 +77,7 @@
       onblur?.(evt);
     }}
     {...restProps}
+    autocomplete="off"
   />
   <div class="field-footer">
     <FieldHint {validationResult} {fieldConfig} {explanation} />


### PR DESCRIPTION
See also [#29275](https://redmine.intranet.terrestris.de/issues/29275).

This PR disables browser autocomplete for date inputs to prevent previously entered values from being restored, [as recommended by MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion).