### PR TITLE
Prevent save feedback for incomplete dates (#29275)

### DIFF
--- a/src/lib/components/Form/Inputs/DateInput.svelte
+++ b/src/lib/components/Form/Inputs/DateInput.svelte
@@ -73,7 +73,11 @@
       restProps.onchange?.(evt as Event & { currentTarget: EventTarget & HTMLInputElement });
     }}
     onblur={(evt) => {
-      value = (evt.currentTarget as HTMLInputElement).value;
+      const input = evt.currentTarget as HTMLInputElement;
+      value = input.value;
+      if (input.validity.badInput) {
+        return;
+      }
       onblur?.(evt);
     }}
     {...restProps}

--- a/tests/integration/TempAndSpatial.integration.ts
+++ b/tests/integration/TempAndSpatial.integration.ts
@@ -66,6 +66,21 @@ export async function testTempAndSpatial(role: string) {
           help: true
         });
       });
+
+      it('does not persist an incomplete published date', async () => {
+        const input = document.querySelector(
+          '.published-field input[type="date"]'
+        ) as HTMLInputElement;
+        const previousCallCount = fetchMock.mock.calls.length;
+
+        Object.defineProperty(input, 'validity', {
+          value: { badInput: true }
+        });
+
+        await fireEvent.blur(input);
+
+        expect(fetchMock.mock.calls).toHaveLength(previousCallCount);
+      });
     });
 
     describe('14_MaintenanceFrequencyField', () => {


### PR DESCRIPTION
See also [#29275](https://redmine.intranet.terrestris.de/issues/29275?journals=all#note-361572).

This PR prevents incomplete date inputs from triggering persistence and displaying the save indicator.