### PR TITLE
fix: update maxLength in e2e-tests

### DIFF
--- a/tests/e2e/form/Basedata.spec.ts
+++ b/tests/e2e/form/Basedata.spec.ts
@@ -52,7 +52,7 @@ test.describe('Metadata form - Basedata section', () => {
       value: 'Test description',
       checkForHelp: true,
       checkForCopy: true,
-      maxLength: 1250,
+      maxLength: 500,
       required: true,
       progressBar: {
         element: progressBar

--- a/tests/e2e/form/Services.spec.ts
+++ b/tests/e2e/form/Services.spec.ts
@@ -73,8 +73,7 @@ test.describe('Metadata form - Services section', () => {
       label: 'Dienst-ID',
       value: opts.serviceId,
       checkForHelp: true,
-      checkForCopy: true,
-      maxLength: 100
+      checkForCopy: true
     });
 
     await testFormField(page, '.service-preview-field', {


### PR DESCRIPTION
This pull request makes minor adjustments to the metadata form fields in the e2e-tests, updating the maximum allowed length for the description field and removing it in the service tab (for id) since these fields do not seem to have a maxLength anymore.
